### PR TITLE
Add Belt Stretch Compensation

### DIFF
--- a/firmware/FluidNC/data/maslow.yaml
+++ b/firmware/FluidNC/data/maslow.yaml
@@ -62,6 +62,9 @@ kinematics:
     brZ: 78.000000
     beltEndExtension: 30.000000
     armLength: 123.400002
+    beltAxialStiffness: 178900.000000
+    sledWeight: 86.328003
+    calibrationPullForce: 156.960007
     beltToothSpacing: 1.998800
     encoderTeeth: 22.000000
     maxSegmentLength: 5.000000

--- a/firmware/FluidNC/src/Channel.h
+++ b/firmware/FluidNC/src/Channel.h
@@ -59,6 +59,12 @@ public:
     virtual void     ack(Error status);
     const char*      name() { return _name; }
 
+    // Bytes buffered in this channel's pending-input queue.  pollLine() pushes
+    // input here whenever the primary loop is too busy to accept a line, and
+    // nothing bounds it, so a steadily rising value means the machine is being
+    // fed faster than it can consume.  Reported by $Heap.
+    size_t queuedBytes() const { return _queue.size(); }
+
     // rx_buffer_available() is the number of bytes that can be sent without overflowing
     // a reception buffer, even if the system is busy.  Channels that can handle external
     // input via an interrupt or other background mechanism should override it to return

--- a/firmware/FluidNC/src/FluidPath.cpp
+++ b/firmware/FluidNC/src/FluidPath.cpp
@@ -7,6 +7,7 @@
 #include "Config.h"
 #include "Error.h"
 #include "HashFS.h"
+#include "Maslow/Maslow.h"  // resetUpdateWatchdog()
 
 int FluidPath::_refcnt = 0;
 
@@ -17,6 +18,12 @@ FluidPath::FluidPath(const char* name, const char* fs, std::error_code* ecptr) :
     if (_isSD) {
         if (_refcnt == 0) {
             std::error_code ec = sd_mount();
+            // Mounting the card runs the full SD init sequence and blocks for
+            // ~100 ms.  Whichever task does it - the protocol task, when a job
+            // is started with $sd/run - is not calling Maslow.update() while it
+            // waits, which trips the 100 ms update watchdog into an emergency
+            // stop.  Same treatment as the other known-blocking operations.
+            Maslow.resetUpdateWatchdog();
             if (ec) {
                 if (ecptr) {
                     *ecptr = ec;
@@ -68,6 +75,7 @@ FluidPath::~FluidPath() {
     // log_debug("~ refcnt " << _isSD << " " << _refcnt);
     if (_isSD && (_refcnt && --_refcnt == 0)) {
         sd_unmount();
+        Maslow.resetUpdateWatchdog();
     }
 }
 

--- a/firmware/FluidNC/src/InputFile.cpp
+++ b/firmware/FluidNC/src/InputFile.cpp
@@ -6,8 +6,10 @@
 #include "Report.h"
 #include "GCode.h"
 
+#include <cstdio>
+
 InputFile::InputFile(const char* defaultFs, const char* path, WebUI::AuthenticationLevel auth_level, Channel& out) :
-    FileStream(path, "r", defaultFs), _auth_level(auth_level), _out(out), _line_num(0) {}
+    FileStream(path, "r", defaultFs), _auth_level(auth_level), _out(out), _line_num(0), _pathCache(FileStream::path()) {}
 /*
   Read a line from the file
   Returns Error::Ok if a line was read, even if the line was empty.
@@ -53,11 +55,8 @@ void InputFile::ack(Error status) {
     _readyNext = true;
 }
 
-std::string InputFile::_progress      = "";
-int32_t     InputFile::_current_line_num = 0;
-
-#include <sstream>
-#include <iomanip>
+char    InputFile::_progress[128]    = "";
+int32_t InputFile::_current_line_num = 0;
 
 Channel* InputFile::pollLine(char* line) {
     // File input never returns realtime characters, so we do nothing
@@ -68,20 +67,21 @@ Channel* InputFile::pollLine(char* line) {
     switch (auto err = readLine(line, Channel::maxLine)) {
         case Error::Ok: {
             _current_line_num = _line_num;
-            std::ostringstream s;
-            s << "SD:" << std::fixed << std::setprecision(2) << percent_complete() << "," << path().c_str();
-            _progress = s.str();
+            // Runs once per GCode line.  The ostringstream version this replaces
+            // allocated a stringbuf, a path() string and two more std::strings on
+            // every single line of the job.
+            snprintf(_progress, sizeof(_progress), "SD:%.2f,%s", percent_complete(), _pathCache.c_str());
         }
             return &allChannels;
         case Error::Eof:
-            _progress         = "";
+            _progress[0]      = '\0';
             _current_line_num = 0;
             _notifyf("File job done", "%s file job succeeded", path());
             log_msg(path() << " file job succeeded");
             allChannels.kill(this);
             return nullptr;
         default:
-            _progress         = "";
+            _progress[0]      = '\0';
             _current_line_num = 0;
             log_error(static_cast<int>(err) << " (" << errorString(err) << ") in " << path() << " at line " << getLineNumber());
             allChannels.kill(this);
@@ -121,6 +121,6 @@ const char* InputFile::getMotionCommandString() {
 }
 
 InputFile::~InputFile() {
-    _progress         = "";
+    _progress[0]      = '\0';
     _current_line_num = 0;
 }

--- a/firmware/FluidNC/src/InputFile.h
+++ b/firmware/FluidNC/src/InputFile.h
@@ -30,9 +30,17 @@ private:
     uint32_t _line_num;  // the most recent line number read
     bool     _readyNext = true;
 
+    // path() builds a std::string every call and the path never changes for the
+    // life of the file, so it is captured once instead of once per GCode line.
+    std::string _pathCache;
+
 public:
-    static std::string _progress;
-    static int32_t     _current_line_num;  // SD file line being processed (for planner threading)
+    // A fixed buffer, not a std::string.  This is rewritten once per GCode line by
+    // the polling task and read by the status reporter, which may run on the other
+    // core; a std::string reallocating under that reader is a use-after-free.  A
+    // fixed buffer also keeps the per-line path free of heap allocation entirely.
+    static char    _progress[128];
+    static int32_t _current_line_num;  // SD file line being processed (for planner threading)
 
     // fsname is the default file system on which the file is located, in case the path does not specify
     // path is the full path to the file

--- a/firmware/FluidNC/src/Kinematics/MaslowKinematics.cpp
+++ b/firmware/FluidNC/src/Kinematics/MaslowKinematics.cpp
@@ -295,6 +295,17 @@ namespace Kinematics {
             motors[1] = computeTR(x, y, z);  // Top Right -> B axis
             motors[2] = computeBL(x, y, z);  // Bottom Left -> C axis
             motors[3] = computeBR(x, y, z);  // Bottom Right -> D axis
+
+            // Belt stretch compensation: the values above are geometric (taut) belt spans. Under
+            // tension the belt elongates, so to place the sled correctly we must pay out slightly
+            // less belt and let it stretch to the target span. Convert each geometric span to the
+            // paid-out length to command, sizing the correction with a static tension estimate.
+            // No-op when compensation is disabled (stiffness <= 0).
+            if (_beltAxialStiffness > 0.0f) {
+                for (int arm = 0; arm < ARM_COUNT; arm++) {
+                    motors[arm] = geometricToPaidOut(motors[arm], estimateBeltTension(arm, x, y, z));
+                }
+            }
         } else {
             // When belts are not ready, keep them at their current positions
             // This prevents the motion planner from synchronizing Z-axis with large belt movements
@@ -384,6 +395,89 @@ namespace Kinematics {
         return lengthInXY + _beltEndExtension + _armLength;  // Add belt end extension and arm length
     }
 
+    // Convert a measured (paid-out / relaxed) belt length to the physical span it bridges once
+    // stretched under the given tension: geometric = paidOut * (1 + F/(A*E)).
+    float MaslowKinematics::paidOutToGeometric(float paidOutLength, float tension) const {
+        if (_beltAxialStiffness > 0.0f && tension > 0.0f) {
+            return paidOutLength * (1.0f + tension / _beltAxialStiffness);
+        }
+        return paidOutLength;
+    }
+
+    // Convert a desired geometric (taut) span to the paid-out length to command so the belt,
+    // once stretched under the given tension, reaches that span: paidOut = geometric / (1 + F/(A*E)).
+    float MaslowKinematics::geometricToPaidOut(float geometricLength, float tension) const {
+        if (_beltAxialStiffness > 0.0f && tension > 0.0f) {
+            return geometricLength / (1.0f + tension / _beltAxialStiffness);
+        }
+        return geometricLength;
+    }
+
+    // Planar static-equilibrium estimate of the tension carried by one belt. The sled is held by
+    // four belts whose XY directions point from the sled toward each anchor; gravity (vertical
+    // machines only) pulls the sled down. Four belts against two force-balance equations is
+    // statically indeterminate, so we take the minimum-norm tension set around a baseline
+    // pretension t0:  T_i = t0 + u_i . lambda,  where (A A^T) lambda = -(W + A t0) and
+    // A = [u_TL u_TR u_BL u_BR]. Tensions are clamped non-negative. Result is in Newtons.
+    float MaslowKinematics::estimateBeltTension(int arm, float x, float y, float z) const {
+        // Sled position in frame coordinates (compute() applies the same center offset).
+        const float sledX = x + _centerX;
+        const float sledY = y + _centerY;
+
+        // Unit vectors from the sled toward each anchor (XY plane).
+        float ux[ARM_COUNT];
+        float uy[ARM_COUNT];
+        for (int i = 0; i < ARM_COUNT; i++) {
+            float dx  = anchor_location[i][Coord_X] - sledX;
+            float dy  = anchor_location[i][Coord_Y] - sledY;
+            float len = sqrtf(dx * dx + dy * dy);
+            if (len < 1e-3f) {
+                // Degenerate: sled coincides with an anchor. Fall back to baseline pretension.
+                return _calibrationPullForce > 0.0f ? _calibrationPullForce : 0.0f;
+            }
+            ux[i] = dx / len;
+            uy[i] = dy / len;
+        }
+
+        // Baseline pretension applied to every belt.
+        const float t0 = _calibrationPullForce > 0.0f ? _calibrationPullForce : 0.0f;
+
+        // External load on the sled (N). A vertical machine loads the belts with gravity along -Y;
+        // a horizontal machine carries the sled on the spoilboard, so there is no in-plane load.
+        const bool  vertical = (Maslow.calibration.orientation == VERTICAL);
+        const float wx       = 0.0f;
+        const float wy       = vertical ? -_sledWeight : 0.0f;
+
+        // Residual load after removing the baseline pretension contribution: b = -(W + A t0).
+        float At0x = 0.0f, At0y = 0.0f;
+        for (int i = 0; i < ARM_COUNT; i++) {
+            At0x += t0 * ux[i];
+            At0y += t0 * uy[i];
+        }
+        const float bx = -(wx + At0x);
+        const float by = -(wy + At0y);
+
+        // M = A A^T (2x2 symmetric).
+        float m00 = 0.0f, m01 = 0.0f, m11 = 0.0f;
+        for (int i = 0; i < ARM_COUNT; i++) {
+            m00 += ux[i] * ux[i];
+            m01 += ux[i] * uy[i];
+            m11 += uy[i] * uy[i];
+        }
+        const float det     = m00 * m11 - m01 * m01;
+        float       lambdaX = 0.0f, lambdaY = 0.0f;
+        if (fabsf(det) > 1e-9f) {
+            lambdaX = (m11 * bx - m01 * by) / det;
+            lambdaY = (-m01 * bx + m00 * by) / det;
+        }
+
+        float tension = t0 + ux[arm] * lambdaX + uy[arm] * lambdaY;
+        if (tension < 0.0f) {
+            tension = 0.0f;
+        }
+        return tension;
+    }
+
     void MaslowKinematics::releaseMotors(AxisMask axisMask, MotorMask motors) {
         // Release the specified motors
         // This is handled by the base motor system
@@ -410,6 +504,9 @@ namespace Kinematics {
         handler.item("brZ", anchor_location[_BR][Coord_Z]);
         handler.item("beltEndExtension", _beltEndExtension);
         handler.item("armLength", _armLength);
+        handler.item("beltAxialStiffness", _beltAxialStiffness);
+        handler.item("sledWeight", _sledWeight);
+        handler.item("calibrationPullForce", _calibrationPullForce);
         handler.item("beltToothSpacing", _beltToothSpacing);
         handler.item("encoderTeeth", _encoderTeeth);
         handler.item("maxSegmentLength", _maxSegmentLength);

--- a/firmware/FluidNC/src/Kinematics/MaslowKinematics.h
+++ b/firmware/FluidNC/src/Kinematics/MaslowKinematics.h
@@ -81,6 +81,22 @@ namespace Kinematics {
         float getCenterX() const { return _centerX; }
         float getCenterY() const { return _centerY; }
 
+        // Belt elasticity (stretch) compensation parameters
+        float getBeltAxialStiffness() const { return _beltAxialStiffness; }
+        float getSledWeight() const { return _sledWeight; }
+        float getCalibrationPullForce() const { return _calibrationPullForce; }
+
+        // Belt stretch helpers. Belts elongate under tension by delta = F * L / (A*E).
+        // These convert between the paid-out (encoder/relaxed) belt length and the physical
+        // (geometric, taut) span the belt bridges under a given tension in Newtons. Both return
+        // their input unchanged when compensation is disabled (stiffness or tension <= 0).
+        float paidOutToGeometric(float paidOutLength, float tension) const;
+        float geometricToPaidOut(float geometricLength, float tension) const;
+
+        // Static gravity + geometry estimate of the tension (N) carried by one belt while the
+        // sled sits at the given position. Used to size the stretch correction during cutting.
+        float estimateBeltTension(int arm, float x, float y, float z) const;
+
         // Forward kinematics methods for position synchronization
         bool  computeXYfromBeltLengths(float tlLength, float trLength, float& x, float& y) const;
         float measurementToXYPlane(float measurement, float zHeight) const;
@@ -107,6 +123,11 @@ namespace Kinematics {
         // Belt and arm parameters (in mm)
         float _beltEndExtension = 30.0f;   // Belt end extension
         float _armLength        = 123.4f;  // Arm length
+
+        // Belt elasticity / stretch compensation parameters
+        float _beltAxialStiffness   = 0.0f;  // Effective axial stiffness A*E (N); belt stretch = F*L/(A*E). 0 disables compensation.
+        float _sledWeight           = 0.0f;  // Sled weight (N) used by the static gravity tension model
+        float _calibrationPullForce = 0.0f;  // Belt tension (N) applied while taking Find Anchors measurements
 
         // Material thickness offsets (in mm) - accounts for spoil board and work piece thickness
         float _spoilboardThickness = 0.0f;  // Spoil board thickness added to all anchor heights

--- a/firmware/FluidNC/src/Maslow/Calibration.cpp
+++ b/firmware/FluidNC/src/Maslow/Calibration.cpp
@@ -603,6 +603,10 @@ bool Calibration::requestStateChange(int newState) {
                 sys.set_state(State::Idle);
                 // Explicitly save belt positions now that calibration/take-slack is complete and belts are tight
                 Maslow.saveBeltPositions();
+                // saveBeltPositions() commits to NVS.  A flash erase/write stalls both cores with
+                // the cache disabled, which can hold off Maslow.update() for longer than
+                // UPDATE_WATCHDOG_MS and trip the emergency stop right as a job is starting.
+                serviceCalibrationWatchdogs();
                 success = true;
                 break;
             } else {

--- a/firmware/FluidNC/src/Maslow/Calibration.cpp
+++ b/firmware/FluidNC/src/Maslow/Calibration.cpp
@@ -49,35 +49,58 @@ namespace {
         bool   converged;       // true if step-norm < threshold within iteration cap
     };
 
-    void bundleResiduals(const std::vector<CalibrationMeasurement>& measurements, const std::vector<double>& params, std::vector<double>& residuals) {
+    // Read one waypoint out of the raw calibration_data block.  The solver reads
+    // measurements straight from that array rather than copying them into a
+    // vector, which keeps 32 bytes per waypoint off the heap during the fit.
+    inline CalibrationMeasurement measurementAt(const float (*data)[4], int index) {
+        return { data[index][0], data[index][1], data[index][2], data[index][3] };
+    }
+
+    // Everything the solver and the fitness gates need to know about the
+    // residuals, accumulated in a single streaming pass.  Materializing the
+    // 4*N residual vector instead would cost several KB of heap at exactly the
+    // moment the ESP32-S3 has the least of it to spare.
+    struct ResidualStats {
+        double ssr                  = 0.0;
+        double maxAbs               = 0.0;
+        int    worstPoint           = 0;
+        int    worstAnchor          = 0;
+        double sumSqPerAnchor[4]    = { 0.0, 0.0, 0.0, 0.0 };
+    };
+
+    ResidualStats computeResidualStats(const float (*data)[4], int count, const std::vector<double>& params) {
+        ResidualStats stats;
+
         const double tlX = params[0], tlY = params[1];
         const double trX = params[2], trY = params[3];
         const double brX = params[4];
 
-        residuals.assign(measurements.size() * 4, 0.0);
-        for (size_t i = 0; i < measurements.size(); i++) {
+        for (int i = 0; i < count; i++) {
             const double sx = params[5 + 2 * i];
             const double sy = params[5 + 2 * i + 1];
-            const auto&  m  = measurements[i];
+            const auto   m  = measurementAt(data, i);
 
             const double dTl = std::sqrt((sx - tlX) * (sx - tlX) + (sy - tlY) * (sy - tlY));
             const double dTr = std::sqrt((sx - trX) * (sx - trX) + (sy - trY) * (sy - trY));
             const double dBl = std::sqrt((sx) * (sx) + (sy) * (sy));
             const double dBr = std::sqrt((sx - brX) * (sx - brX) + (sy) * (sy));
 
-            residuals[4 * i + 0] = dTl - m.tl;
-            residuals[4 * i + 1] = dTr - m.tr;
-            residuals[4 * i + 2] = dBl - m.bl;
-            residuals[4 * i + 3] = dBr - m.br;
-        }
-    }
+            const double r[4] = { dTl - m.tl, dTr - m.tr, dBl - m.bl, dBr - m.br };
 
-    double sumSquaredResiduals(const std::vector<double>& residuals) {
-        double sum = 0.0;
-        for (const double r : residuals) {
-            sum += r * r;
+            for (int j = 0; j < 4; j++) {
+                stats.ssr += r[j] * r[j];
+                stats.sumSqPerAnchor[j] += r[j] * r[j];
+
+                const double ar = std::abs(r[j]);
+                if (ar > stats.maxAbs) {
+                    stats.maxAbs      = ar;
+                    stats.worstPoint  = i;
+                    stats.worstAnchor = j;
+                }
+            }
         }
-        return sum;
+
+        return stats;
     }
 
     void estimateSledPosition(const CalibrationMeasurement& measurement, double tlX, double tlY, double trX, double trY, double brX, double& sx, double& sy) {
@@ -778,11 +801,8 @@ bool Calibration::recomputeAnchorsWithLevenbergMarquardt(int measurementCount) {
             return false;
         }
 
-        std::vector<CalibrationMeasurement> measurements;
-        measurements.reserve(measurementCount);
-        for (int i = 0; i < measurementCount; i++) {
-            measurements.push_back({ calibration_data[i][0], calibration_data[i][1], calibration_data[i][2], calibration_data[i][3] });
-        }
+        // Measurements are read directly out of calibration_data; no copy is made.
+        const float (*measurements)[4] = calibration_data;
 
         // Capture initial anchor estimates for retry perturbations
         const double tlX0 = kinematics->getTlX();
@@ -831,25 +851,28 @@ bool Calibration::recomputeAnchorsWithLevenbergMarquardt(int measurementCount) {
             params.push_back(trY0 + py);
             params.push_back(brX0);
 
-            for (const auto& measurement : measurements) {
+            for (int i = 0; i < measurementCount; i++) {
                 serviceCalibrationWatchdogs(true);
                 double sx = 0.0;
                 double sy = 0.0;
-                estimateSledPosition(measurement, params[0], params[1], params[2], params[3], params[4], sx, sy);
+                estimateSledPosition(measurementAt(measurements, i), params[0], params[1], params[2], params[3], params[4], sx, sy);
                 params.push_back(sx);
                 params.push_back(sy);
             }
 
-            std::vector<double> residuals;
-            bundleResiduals(measurements, params, residuals);
-            double currentSSR = sumSquaredResiduals(residuals);
+            double currentSSR = computeResidualStats(measurements, measurementCount, params).ssr;
 
-            std::vector<double> bestParams = params;
+            // The best parameter set is tracked only in globalBestParams; keeping a
+            // second per-attempt copy would double the largest vector in the solver.
+            if (currentSSR < globalBestSSR) {
+                globalBestSSR    = currentSSR;
+                globalBestParams = params;
+            }
+
             double              bestSSR    = currentSSR;
             double              lambda     = LM_INITIAL_LAMBDA;
             int                 rejections = 0;
             std::vector<double> nextParams;
-            std::vector<double> nextResiduals;
             int                 iterationCount = 0;
 
         for (int iteration = 0; iteration < LM_MAX_ITERATIONS; iteration++) {
@@ -865,15 +888,28 @@ bool Calibration::recomputeAnchorsWithLevenbergMarquardt(int measurementCount) {
             double schurSub[5][5] = {};
             double schurGain[5] = {};
 
-            for (size_t i = 0; i < measurements.size(); i++) {
+            for (int i = 0; i < measurementCount; i++) {
                 const size_t sxIndex = 5 + 2 * i;
                 const size_t syIndex = sxIndex + 1;
 
                 double w[5][2];
                 double gi[2];
                 double v00 = 0.0, v01 = 0.0, v11 = 0.0;
-                accumulatePointBlocks(
-                    measurements[i], tlX, tlY, trX, trY, brX, params[sxIndex], params[syIndex], u, ga, w, gi, v00, v01, v11);
+                accumulatePointBlocks(measurementAt(measurements, i),
+                                      tlX,
+                                      tlY,
+                                      trX,
+                                      trY,
+                                      brX,
+                                      params[sxIndex],
+                                      params[syIndex],
+                                      u,
+                                      ga,
+                                      w,
+                                      gi,
+                                      v00,
+                                      v01,
+                                      v11);
 
                 double invV[2][2];
                 if (!invertDamped2x2(v00, v01, v11, lambda, invV)) {
@@ -919,7 +955,7 @@ bool Calibration::recomputeAnchorsWithLevenbergMarquardt(int measurementCount) {
                 nextParams[i] += anchorStep[i];
             }
 
-            for (size_t i = 0; i < measurements.size(); i++) {
+            for (int i = 0; i < measurementCount; i++) {
                 const size_t sxIndex = 5 + 2 * i;
                 const size_t syIndex = sxIndex + 1;
                 const double sx      = params[sxIndex];
@@ -928,7 +964,7 @@ bool Calibration::recomputeAnchorsWithLevenbergMarquardt(int measurementCount) {
                 double jia[4][5];
                 double jis[4][2];
                 double ri[4];
-                measurementJacobiansAndResiduals(measurements[i], tlX, tlY, trX, trY, brX, sx, sy, jia, jis, ri);
+                measurementJacobiansAndResiduals(measurementAt(measurements, i), tlX, tlY, trX, trY, brX, sx, sy, jia, jis, ri);
 
                 double v00 = 0.0, v01 = 0.0, v11 = 0.0;
                 double gi[2] = {};
@@ -966,19 +1002,23 @@ bool Calibration::recomputeAnchorsWithLevenbergMarquardt(int measurementCount) {
                 nextParams[syIndex] += syStep;
             }
 
-            bundleResiduals(measurements, nextParams, nextResiduals);
-            const double nextSSR = sumSquaredResiduals(nextResiduals);
+            const double nextSSR = computeResidualStats(measurements, measurementCount, nextParams).ssr;
 
             if (nextSSR < currentSSR) {
-                params = std::move(nextParams);
-                residuals = std::move(nextResiduals);
+                // Swap rather than move: nextParams keeps the old buffer, so the
+                // "nextParams = params" copy at the top of the next iteration reuses
+                // it instead of reallocating on every accepted step.
+                std::swap(params, nextParams);
                 currentSSR = nextSSR;
                 lambda = std::max(lambda * LM_LAMBDA_DECREASE, 1e-12);
                 rejections = 0;
 
                 if (currentSSR < bestSSR) {
                     bestSSR = currentSSR;
-                    bestParams = params;
+                }
+                if (currentSSR < globalBestSSR) {
+                    globalBestSSR    = currentSSR;
+                    globalBestParams = params;
                 }
 
                 double anchorStepNorm = 0.0;
@@ -1001,11 +1041,6 @@ bool Calibration::recomputeAnchorsWithLevenbergMarquardt(int measurementCount) {
             log_debug("Find Anchors LM attempt=" << attempt << " iterations=" << iterationCount
                                                  << " bestSSR=" << bestSSR << " converged=" << thisConverged);
 
-            if (bestSSR < globalBestSSR) {
-                globalBestSSR    = bestSSR;
-                globalBestParams = bestParams;
-            }
-
             if (thisConverged) {
                 anyConverged = true;
                 break;
@@ -1014,29 +1049,23 @@ bool Calibration::recomputeAnchorsWithLevenbergMarquardt(int measurementCount) {
 
         serviceCalibrationWatchdogs(true);
 
-        // ── Fitness computation ────────────────────────────────────────────────
-        std::vector<double> finalRes;
-        bundleResiduals(measurements, globalBestParams, finalRes);
-
-        CalibrationFitness fit;
-        fit.rms       = std::sqrt(globalBestSSR / (4.0 * measurementCount));
-        fit.converged = anyConverged;
-
-        fit.maxResidual = 0.0;
-        for (const double r : finalRes) {
-            const double ar = std::abs(r);
-            if (ar > fit.maxResidual) {
-                fit.maxResidual = ar;
-            }
+        // globalBestParams stays empty only if every SSR came back NaN, in which
+        // case there is nothing to report or persist.
+        if (globalBestParams.empty()) {
+            log_error("Find Anchors recompute failed: no usable solution at points=" << measurementCount);
+            return false;
         }
 
+        // ── Fitness computation ────────────────────────────────────────────────
+        const ResidualStats finalStats = computeResidualStats(measurements, measurementCount, globalBestParams);
+
+        CalibrationFitness fit;
+        fit.rms         = std::sqrt(globalBestSSR / (4.0 * measurementCount));
+        fit.converged   = anyConverged;
+        fit.maxResidual = finalStats.maxAbs;
+
         for (int j = 0; j < 4; j++) {
-            double sumSq = 0.0;
-            for (int i = 0; i < measurementCount; i++) {
-                const double r = finalRes[4 * i + j];
-                sumSq += r * r;
-            }
-            fit.rmsPerAnchor[j] = std::sqrt(sumSq / measurementCount);
+            fit.rmsPerAnchor[j] = std::sqrt(finalStats.sumSqPerAnchor[j] / measurementCount);
         }
 
         // ── Fitness gates ──────────────────────────────────────────────────────
@@ -1053,22 +1082,12 @@ bool Calibration::recomputeAnchorsWithLevenbergMarquardt(int measurementCount) {
             return false;
         }
 
-        // Gate 3: max residual — find worst anchor/measurement index for the log
+        // Gate 3: max residual — the worst anchor/measurement index came out of the
+        // same streaming pass that produced maxResidual.
         if (fit.maxResidual > FITNESS_MAX_RES_FAIL_MM) {
-            int    worstI = 0, worstJ = 0;
-            double worstVal = 0.0;
-            for (int i = 0; i < measurementCount; i++) {
-                for (int j = 0; j < 4; j++) {
-                    const double ar = std::abs(finalRes[4 * i + j]);
-                    if (ar > worstVal) {
-                        worstVal = ar;
-                        worstI   = i;
-                        worstJ   = j;
-                    }
-                }
-            }
-            log_error("Find Anchors fit failed: maxResidual=" << fit.maxResidual << "mm at anchor=" << worstJ
-                                                              << " measurement=" << worstI << " (limit " << FITNESS_MAX_RES_FAIL_MM << "mm)");
+            log_error("Find Anchors fit failed: maxResidual=" << fit.maxResidual << "mm at anchor=" << finalStats.worstAnchor
+                                                              << " measurement=" << finalStats.worstPoint << " (limit "
+                                                              << FITNESS_MAX_RES_FAIL_MM << "mm)");
             return false;
         }
 
@@ -1279,7 +1298,7 @@ bool Calibration::takeSlackFunc() {
             }
 
             log_warn("Maslow Apply Tension retraction warning: Belt "
-                     << Maslow.axis_id_to_label(arm).c_str() << " retracted " << retractedAmount
+                     << Maslow.axis_id_to_label(arm) << " retracted " << retractedAmount
                      << "mm while applying tension (limit " << applyTensionBeltRetractionLimitMm
                      << "mm). A belt may not be anchored. Continue to keep retracting or Cancel to stop. Reduce Extend Dist or extend Belt Retraction Limit (Options) if Belts Attached to Anchors. Release Tension will allow Approx. 10mm of belt to be released.");
 
@@ -1758,22 +1777,11 @@ bool Calibration::take_measurement(float result[4], int dir, int run, int curren
     return false;
 }
 
-static float** measurements = nullptr;
-
-void allocateMeasurements() {
-    measurements = new float*[4];
-    for (int i = 0; i < 4; ++i) {
-        measurements[i] = new float[4];
-    }
-}
-
-void freeMeasurements() {
-    for (int i = 0; i < 4; ++i) {
-        delete[] measurements[i];
-    }
-    delete[] measurements;
-    measurements = nullptr;
-}
+// Scratch space for the repeated readings taken at a single waypoint, structured
+// [[tl],[tr],[bl],[br]] x 4 runs.  This was five separate heap blocks allocated and
+// freed on every waypoint; 64 bytes of static storage holds it without churning
+// the heap between the large transient allocations the recompute makes.
+static float measurements[4][4];
 
 // Takes a series of measurements, calculates average and records calibration data;  Returns true when it's done and the result has been stored
 // There is way too much being done in this function. It needs to be split apart and cleaned up
@@ -1783,10 +1791,6 @@ bool Calibration::take_measurement_avg_with_check(int waypoint, int dir) {
     static float avg         = 0;
     static float sum         = 0;
     static bool  measureFlex = false;
-
-    if (measurements == nullptr) {
-        allocateMeasurements();  //This is structured [[tl],[tr],[bl],[br]],[[tl],[tr],[bl],[br]],[[tl],[tr],[bl],[br]],[[tl],[tr],[bl],[br]]
-    }
 
     int howHardToPull = retractCurrentThreshold;
     if (measureFlex) {
@@ -1826,7 +1830,7 @@ bool Calibration::take_measurement_avg_with_check(int waypoint, int dir) {
                 for (int i = 0; i < 4; i++) {
                     for (int j = 0; j < 4; j++) {
                         //use axis id to label:
-                        log_info(Maslow.axis_id_to_label(i).c_str() << " " << measurements[j][i]);
+                        log_info(Maslow.axis_id_to_label(i) << " " << measurements[j][i]);
                     }
                 }
                 //reset the run counter to run the measurements again
@@ -1834,11 +1838,9 @@ bool Calibration::take_measurement_avg_with_check(int waypoint, int dir) {
                     log_error("Critical error, measurements are not within 1.5mm of each other 8 times in a row, stopping Find Anchors");
                     resetCalibrationState();
                     criticalCounter = 0;
-                    freeMeasurements();
                     requestStateChange(EXTENDEDOUT);
                     return false;
                 }
-                freeMeasurements();
                 return false;
             }
 
@@ -1859,7 +1861,7 @@ bool Calibration::take_measurement_avg_with_check(int waypoint, int dir) {
 
                 measureFlex = false;
 
-                freeMeasurements();  //We have completed this measurement, but we don't want to store anything this time
+                //We have completed this measurement, but we don't want to store anything this time
                 return true;
             }
             */
@@ -1903,7 +1905,6 @@ bool Calibration::take_measurement_avg_with_check(int waypoint, int dir) {
                         Maslow.eStop("Unable to find a valid frame size to match the first measurement");
                         resetCalibrationState();
                         criticalCounter = 0;
-                        freeMeasurements();
                         requestStateChange(EXTENDEDOUT);
                         return false;
                     }
@@ -1914,7 +1915,6 @@ bool Calibration::take_measurement_avg_with_check(int waypoint, int dir) {
                     Maslow.eStop("Unable to find machine position from measurements");
                     resetCalibrationState();
                     criticalCounter = 0;
-                    freeMeasurements();
                     requestStateChange(EXTENDEDOUT);
                     return false;
                 }
@@ -1936,9 +1936,6 @@ bool Calibration::take_measurement_avg_with_check(int waypoint, int dir) {
                 calibrationGrid[5][0] = x - 150;
                 calibrationGrid[5][1] = y;
             }
-
-            //This is the exit to indicate that the measurement was successful
-            freeMeasurements();
 
             //Special case where we have a good measurement but we need to take another at this point to measure the flex of the frame
             //Frame flex should only be measured during calibration process, not during "Apply Tension"
@@ -2423,10 +2420,7 @@ void Calibration::allocateCalibrationMemory() {
         calibrationGrid = new float[CALIBRATION_GRID_SIZE_MAX][2];
     }
     if (calibration_data == nullptr) {
-        calibration_data = new float*[CALIBRATION_GRID_SIZE_MAX];
-        for (int i = 0; i < CALIBRATION_GRID_SIZE_MAX; ++i) {
-            calibration_data[i] = new float[4];
-        }
+        calibration_data = new float[CALIBRATION_GRID_SIZE_MAX][4];
     }
 }
 
@@ -2434,9 +2428,6 @@ void Calibration::allocateCalibrationMemory() {
 void Calibration::deallocateCalibrationMemory() {
     delete[] calibrationGrid;
     calibrationGrid = nullptr;
-    for (int i = 0; i < CALIBRATION_GRID_SIZE_MAX; ++i) {
-        delete[] calibration_data[i];
-    }
     delete[] calibration_data;
     calibration_data = nullptr;
 }

--- a/firmware/FluidNC/src/Maslow/Calibration.cpp
+++ b/firmware/FluidNC/src/Maslow/Calibration.cpp
@@ -1545,10 +1545,13 @@ bool Calibration::take_measurement(float result[4], int dir, int run, int curren
             float brTotalZ = (currentZ + kinematics->getBrZ() + kinematics->getSpoilboardThickness() + kinematics->getWorkThickness());
 
             //take measurement and record it to the calibration data array.
-            result[0] = measurementToXYPlane(Maslow.axis[_TL].getPosition(), tlTotalZ);
-            result[1] = measurementToXYPlane(Maslow.axis[_TR].getPosition(), trTotalZ);
-            result[2] = measurementToXYPlane(Maslow.axis[_BL].getPosition(), blTotalZ);
-            result[3] = measurementToXYPlane(Maslow.axis[_BR].getPosition(), brTotalZ);
+            //Correct the measured (paid-out) belt lengths for elastic stretch under the Find Anchors
+            //pull tension so the stored data reflects the true geometric span (no-op when disabled).
+            const float pullForce = kinematics->getCalibrationPullForce();
+            result[0] = measurementToXYPlane(kinematics->paidOutToGeometric(Maslow.axis[_TL].getPosition(), pullForce), tlTotalZ);
+            result[1] = measurementToXYPlane(kinematics->paidOutToGeometric(Maslow.axis[_TR].getPosition(), pullForce), trTotalZ);
+            result[2] = measurementToXYPlane(kinematics->paidOutToGeometric(Maslow.axis[_BL].getPosition(), pullForce), blTotalZ);
+            result[3] = measurementToXYPlane(kinematics->paidOutToGeometric(Maslow.axis[_BR].getPosition(), pullForce), brTotalZ);
             BR_tight  = false;
             BL_tight  = false;
             return true;
@@ -1643,10 +1646,12 @@ bool Calibration::take_measurement(float result[4], int dir, int run, int curren
                 float brTotalZ = (currentZ + kinematics->getBrZ() + kinematics->getSpoilboardThickness() + kinematics->getWorkThickness());
 
                 //take measurement and record it to the calibration data array.
-                result[0] = measurementToXYPlane(Maslow.axis[_TL].getPosition(), tlTotalZ);
-                result[1] = measurementToXYPlane(Maslow.axis[_TR].getPosition(), trTotalZ);
-                result[2] = measurementToXYPlane(Maslow.axis[_BL].getPosition(), blTotalZ);
-                result[3] = measurementToXYPlane(Maslow.axis[_BR].getPosition(), brTotalZ);
+                //Correct measured (paid-out) belt lengths for elastic stretch under the pull tension.
+                const float pullForce = kinematics->getCalibrationPullForce();
+                result[0] = measurementToXYPlane(kinematics->paidOutToGeometric(Maslow.axis[_TL].getPosition(), pullForce), tlTotalZ);
+                result[1] = measurementToXYPlane(kinematics->paidOutToGeometric(Maslow.axis[_TR].getPosition(), pullForce), trTotalZ);
+                result[2] = measurementToXYPlane(kinematics->paidOutToGeometric(Maslow.axis[_BL].getPosition(), pullForce), blTotalZ);
+                result[3] = measurementToXYPlane(kinematics->paidOutToGeometric(Maslow.axis[_BR].getPosition(), pullForce), brTotalZ);
                 // Reset all flags for next measurement
                 tight[_TL]               = false;
                 tight[_TR]               = false;
@@ -1737,10 +1742,12 @@ bool Calibration::take_measurement(float result[4], int dir, int run, int curren
                 float brTotalZ = (currentZ + kinematics->getBrZ() + kinematics->getSpoilboardThickness() + kinematics->getWorkThickness());
 
                 //take measurement and record it to the calibration data array.
-                result[0]   = measurementToXYPlane(Maslow.axis[_TL].getPosition(), tlTotalZ);
-                result[1]   = measurementToXYPlane(Maslow.axis[_TR].getPosition(), trTotalZ);
-                result[2]   = measurementToXYPlane(Maslow.axis[_BL].getPosition(), blTotalZ);
-                result[3]   = measurementToXYPlane(Maslow.axis[_BR].getPosition(), brTotalZ);
+                //Correct measured (paid-out) belt lengths for elastic stretch under the pull tension.
+                const float pullForce = kinematics->getCalibrationPullForce();
+                result[0]   = measurementToXYPlane(kinematics->paidOutToGeometric(Maslow.axis[_TL].getPosition(), pullForce), tlTotalZ);
+                result[1]   = measurementToXYPlane(kinematics->paidOutToGeometric(Maslow.axis[_TR].getPosition(), pullForce), trTotalZ);
+                result[2]   = measurementToXYPlane(kinematics->paidOutToGeometric(Maslow.axis[_BL].getPosition(), pullForce), blTotalZ);
+                result[3]   = measurementToXYPlane(kinematics->paidOutToGeometric(Maslow.axis[_BR].getPosition(), pullForce), brTotalZ);
                 pull1_tight = false;
                 pull2_tight = false;
                 return true;

--- a/firmware/FluidNC/src/Maslow/Calibration.h
+++ b/firmware/FluidNC/src/Maslow/Calibration.h
@@ -105,7 +105,10 @@ private:
     bool takeSlack = false;
 
     //Variables used by calibration
-    float** calibration_data      = nullptr;
+    // One contiguous [point][TL,TR,BL,BR] block rather than a row-pointer array.
+    // Indexing is unchanged; the single allocation avoids CALIBRATION_GRID_SIZE_MAX
+    // tiny heap blocks and their per-block allocator overhead.
+    float (*calibration_data)[4]  = nullptr;
     int     pointCount            = 0;     //number of actual points in the grid,  < GRID_SIZE_MAX
     int     waypoint              = 0;     //The current waypoint in the calibration process
     int     calibrationDirection  = 0;     //Direction for calibration measurements (replaces static variable)

--- a/firmware/FluidNC/src/Maslow/Maslow.cpp
+++ b/firmware/FluidNC/src/Maslow/Maslow.cpp
@@ -192,6 +192,10 @@ void Maslow_::update() {
         if (currentMaslowState == READY_TO_CUT || currentMaslowState == RETRACTED || currentMaslowState == EXTENDEDOUT) {
             saveBeltPositions();
         }
+        // Both saves commit to NVS, and the flash write stalls both cores.  That time is
+        // spent inside this call to update(), so it would otherwise be charged against the
+        // watchdog budget checked below and trip the emergency stop.
+        resetUpdateWatchdog();
     }
 
     // Track state changes and mark belt positions as stale when leaving valid states
@@ -219,10 +223,15 @@ void Maslow_::update() {
         if (!uploadInProgress && now - lastCallToUpdate > UPDATE_WATCHDOG_MS) {
             unsigned int elapsedTime = now - lastCallToUpdate;
             log_error("Emergency stop. Update function not being called enough. " << elapsedTime << "ms since last call");
+            log_error("  longest phase: " << worstActivity << " (" << (uint32_t)worstActivityMs << "ms), now in: "
+                                          << (const char*)lastActivity << " (" << (uint32_t)(now - lastActivityStart)
+                                          << "ms), sys.state=" << state_name()
+                                          << ", maslowState=" << calibration.getCurrentState());
             watchdogFired = true;
             Maslow.panic();
         }
         lastCallToUpdate = now;
+        clearWorstActivity();
 
         Maslow.updateEncoderPositions();  //We always update encoder positions in any state,
 

--- a/firmware/FluidNC/src/Maslow/Maslow.cpp
+++ b/firmware/FluidNC/src/Maslow/Maslow.cpp
@@ -360,14 +360,14 @@ bool Maslow_::updateEncoderPositions() {
     if (millis() - encoderFailTimer > 1000) {
         for (int i = 0; i < 4; i++) {
             //turn i into proper label
-            String label = axis_id_to_label(i);
+            const char* label = axis_id_to_label(i);
             if (encoderFailCounter[i] > 0.1 * ENCODER_READ_FREQUENCY_HZ) {
                 // log error statement with appropriate label
-                log_error("Failure on " << label.c_str() << " encoder, failed to read " << encoderFailCounter[i]
+                log_error("Failure on " << label << " encoder, failed to read " << encoderFailCounter[i]
                                         << " times in the last second");
                 Maslow.panic();
             } else if (encoderFailCounter[i] > 0) {  //0.01*ENCODER_READ_FREQUENCY_HZ){
-                log_warn("Bad connection on " << label.c_str() << " encoder, failed to read " << encoderFailCounter[i]
+                log_warn("Bad connection on " << label << " encoder, failed to read " << encoderFailCounter[i]
                                               << " times in the last second");
             }
             encoderFailCounter[i] = 0;
@@ -987,23 +987,18 @@ void Maslow_::markBeltPositionsStale() {
 //------------------------------------------------------
 
 // int to string name conversion for axis labels
-String Maslow_::axis_id_to_label(int axis_id) {
-    String label;
+const char* Maslow_::axis_id_to_label(int axis_id) {
     switch (axis_id) {
         case TLEncoderLine:
-            label = "Top Left";
-            break;
+            return "Top Left";
         case TREncoderLine:
-            label = "Top Right";
-            break;
+            return "Top Right";
         case BREncoderLine:
-            label = "Bottom Right";
-            break;
+            return "Bottom Right";
         case BLEncoderLine:
-            label = "Bottom Left";
-            break;
+            return "Bottom Left";
     }
-    return label;
+    return "";
 }
 
 //Runs the self test feature
@@ -1225,7 +1220,7 @@ void Maslow_::safety_control() {
             panicCounter[i]++;
             if (panicCounter[i] > tresholdHitsBeforePanic) {
                 if (sys.state() == State::Jog || sys.state() == State::Cycle) {
-                    log_warn("Motor current on " << axis_id_to_label(i).c_str() << " axis exceeded threshold of " << 4000);
+                    log_warn("Motor current on " << axis_id_to_label(i) << " axis exceeded threshold of " << 4000);
                     //Maslow.panic();
                 }
                 tick[i] = true;
@@ -1245,10 +1240,10 @@ void Maslow_::safety_control() {
         if (axis[i].getMotorPower() > 450 && abs(axis[i].getBeltSpeed()) < 0.1 && !tick[i]) {
             axisSlackCounter[i]++;
             if (axisSlackCounter[i] > 3000) {
-                // log_info("SLACK:" << axis_id_to_label(i).c_str() << " motor power is " << int(axis[i].getMotorPower())
+                // log_info("SLACK:" << axis_id_to_label(i) << " motor power is " << int(axis[i].getMotorPower())
                 //                   << ", but the belt speed is" << axis[i].getBeltSpeed());
                 // log_info(axisSlackCounter[i]);
-                // log_info("Pull on " << axis_id_to_label(i).c_str() << " and restart!");
+                // log_info("Pull on " << axis_id_to_label(i) << " and restart!");
                 tick[i]             = true;
                 axisSlackCounter[i] = 0;
                 Maslow.panic();
@@ -1258,7 +1253,7 @@ void Maslow_::safety_control() {
 
         //If the motor has a position error greater than 1mm and we are running a file or jogging
         if ((abs(axis[i].getPositionError()) > 1) && (sys.state() == State::Jog || sys.state() == State::Cycle) && !tick[i]) {
-            // log_error("Position error on " << axis_id_to_label(i).c_str() << " axis exceeded 1mm, error is " << axis[i].getPositionError()
+            // log_error("Position error on " << axis_id_to_label(i) << " axis exceeded 1mm, error is " << axis[i].getPositionError()
             //                                << "mm");
             tick[i] = true;
         }
@@ -1267,7 +1262,7 @@ void Maslow_::safety_control() {
         previousPositionError[i] = axis[i].getPositionError();
         if ((abs(axis[i].getPositionError()) > 15) && (sys.state() == State::Cycle)) {
             positionErrorCounter[i]++;
-            log_warn("Position error on " << axis_id_to_label(i).c_str() << " axis exceeded 15mm while running. Error is "
+            log_warn("Position error on " << axis_id_to_label(i) << " axis exceeded 15mm while running. Error is "
                                           << axis[i].getPositionError() << "mm" << " Counter: " << positionErrorCounter[i]);
             log_warn("Previous error was " << previousPositionError[i] << "mm");
 
@@ -1337,6 +1332,11 @@ void Maslow_::set_telemetry(bool enabled) {
         // }
     }
     telemetry_enabled = enabled;
+    if (enabled) {
+        // The telemetry task is created lazily so its stack does not sit in the
+        // heap on machines that never turn telemetry on.
+        ensure_telemetry_task();
+    }
     log_info("Telemetry: " << (enabled ? "enabled" : "disabled"));
 }
 

--- a/firmware/FluidNC/src/Maslow/Maslow.h
+++ b/firmware/FluidNC/src/Maslow/Maslow.h
@@ -3,6 +3,7 @@
 // following exception: it may not be used for any reason by MakerMade or anyone with a business or personal connection to MakerMade
 
 #pragma once
+#include <cstring>  // strncpy for the watchdog activity breadcrumb
 #include <Arduino.h>
 #include "MaslowEnums.h"
 #include "MotorUnit.h"
@@ -119,6 +120,37 @@ public:
     // Flash write operations stall both CPU cores; without this flag the 100 ms
     // watchdog fires spuriously and latches the red LED until a power cycle.
     volatile bool uploadInProgress = false;
+
+    // Breadcrumb for diagnosing update-loop watchdog trips.  The protocol task is
+    // the only caller of update(), so a gap means that task was blocked somewhere.
+    // markActivity() records what it was about to do and when, and the watchdog
+    // reports it, turning "something stalled" into "this stalled".
+    volatile const char*   lastActivity      = "startup";
+    volatile unsigned long lastActivityStart = 0;
+    // The phase that ended when the current one began, and how long it took.
+    // update() runs at the end of a phase, so the phase that consumed the time
+    // is the *previous* one; reporting only the current one erases the evidence.
+    // One level of history is not enough - several phases run between the one
+    // that stalls and the watchdog check, so the interesting duration gets
+    // overwritten.  Track the longest phase seen since the last update() call.
+    char                   worstActivity[120] = "startup";
+    volatile unsigned long worstActivityMs    = 0;
+    void markActivity(const char* what) {
+        unsigned long now      = millis();
+        unsigned long duration = now - lastActivityStart;
+        if (duration > worstActivityMs) {
+            worstActivityMs = duration;
+            // Copy rather than alias: line buffers are reused by the polling task.
+            strncpy(worstActivity, lastActivity ? (const char*)lastActivity : "?", sizeof(worstActivity) - 1);
+            worstActivity[sizeof(worstActivity) - 1] = '\0';
+        }
+        lastActivity      = what;
+        lastActivityStart = now;
+    }
+    void clearWorstActivity() {
+        worstActivityMs = 0;
+        worstActivity[0] = '\0';
+    }
     // Returns a string literal, not a String.  This is called on every encoder
     // read, and an Arduino String would heap-allocate and free each time.
     const char* axis_id_to_label(int axis_id);

--- a/firmware/FluidNC/src/Maslow/Maslow.h
+++ b/firmware/FluidNC/src/Maslow/Maslow.h
@@ -119,7 +119,9 @@ public:
     // Flash write operations stall both CPU cores; without this flag the 100 ms
     // watchdog fires spuriously and latches the red LED until a power cycle.
     volatile bool uploadInProgress = false;
-    String axis_id_to_label(int axis_id);
+    // Returns a string literal, not a String.  This is called on every encoder
+    // read, and an Arduino String would heap-allocate and free each time.
+    const char* axis_id_to_label(int axis_id);
     void   safety_control();
     bool   axis_homed[4] = { false, false, false, false };
 

--- a/firmware/FluidNC/src/Maslow/MotorUnit.cpp
+++ b/firmware/FluidNC/src/Maslow/MotorUnit.cpp
@@ -19,15 +19,15 @@
 void MotorUnit::begin(int forwardPin, int backwardPin, int readbackPin, int encoderAddress, int channel1, int channel2) {
     _encoderAddress = encoderAddress;
 
-    String encAddrLabel = Maslow.axis_id_to_label(_encoderAddress);
+    const char* encAddrLabel = Maslow.axis_id_to_label(_encoderAddress);
 
     Maslow.I2CMux.setPort(_encoderAddress);
     if (!encoder.begin()) {
-        log_error("Encoder not found on " << encAddrLabel.c_str());
+        log_error("Encoder not found on " << encAddrLabel);
         Maslow.error        = true;
-        Maslow.errorMessage = "Encoder not found on " + encAddrLabel;
+        Maslow.errorMessage = String("Encoder not found on ") + encAddrLabel;
     } else {
-        log_info("Encoder connected on " << encAddrLabel.c_str());
+        log_info("Encoder connected on " << encAddrLabel);
     }
     zero();
 
@@ -37,11 +37,11 @@ void MotorUnit::begin(int forwardPin, int backwardPin, int readbackPin, int enco
     positionPID.setOutputLimits(-1023, 1023);
 
     if (!motor_test()) {
-        log_error("Motor not found on " << encAddrLabel.c_str());
+        log_error("Motor not found on " << encAddrLabel);
         Maslow.error        = true;
-        Maslow.errorMessage = "Motor not found on " + encAddrLabel;
+        Maslow.errorMessage = String("Motor not found on ") + encAddrLabel;
     } else {
-        log_info("Motor detected on " << encAddrLabel.c_str());
+        log_info("Motor detected on " << encAddrLabel);
     }
 }
 
@@ -49,32 +49,32 @@ void MotorUnit::begin(int forwardPin, int backwardPin, int readbackPin, int enco
 bool MotorUnit::test() {
     bool allTestsPassed = true;
 
-    String encAddrLabel = Maslow.axis_id_to_label(_encoderAddress);
+    const char* encAddrLabel = Maslow.axis_id_to_label(_encoderAddress);
 
     //Check if the motor / motor driver are connected
     if (!motor_test()) {
-        log_warn("Motor not found on " << encAddrLabel.c_str());
+        log_warn("Motor not found on " << encAddrLabel);
         Maslow.error        = true;
-        Maslow.errorMessage = "Motor not found on " + encAddrLabel;
+        Maslow.errorMessage = String("Motor not found on ") + encAddrLabel;
         allTestsPassed      = false;
     }
 
     //Check if the encoder is connected
     if (!updateEncoderPosition()) {
-        log_warn("Encoder not found on " << encAddrLabel.c_str());
+        log_warn("Encoder not found on " << encAddrLabel);
         Maslow.error        = true;
-        Maslow.errorMessage = "Encoder not found on " + encAddrLabel;
+        Maslow.errorMessage = String("Encoder not found on ") + encAddrLabel;
         allTestsPassed      = false;
     }
 
     //Check for the presence of the magnet
     if (!encoder.detectMagnet()) {
-        log_warn("Magnet not detected on " << encAddrLabel.c_str());
+        log_warn("Magnet not detected on " << encAddrLabel);
         allTestsPassed = false;
     }
 
     if (allTestsPassed) {
-        log_info("All tests passed on " << encAddrLabel.c_str());
+        log_info("All tests passed on " << encAddrLabel);
     }
 
     return !Maslow.error;
@@ -119,7 +119,7 @@ bool MotorUnit::updateEncoderPosition() {
     if (!Maslow.I2CMux.setPort(_encoderAddress))
         return false;
 
-    String encAddrLabel = Maslow.axis_id_to_label(_encoderAddress);
+    const char* encAddrLabel = Maslow.axis_id_to_label(_encoderAddress);
 
     if (encoder.isConnected()) {                                               //this func has 50ms timeout (or worse?, hard to tell)
         mostRecentCumulativeEncoderReading = encoder.getCumulativePosition();  //This updates and returns the encoder value
@@ -129,14 +129,14 @@ bool MotorUnit::updateEncoderPosition() {
         if (error != 0) {  // AS5600_OK = 0
             if (millis() - encoderReadFailurePrintTime > 5000) {
                 encoderReadFailurePrintTime = millis();
-                log_warn("Encoder I2C error " << error << " on " << encAddrLabel.c_str());
+                log_warn("Encoder I2C error " << error << " on " << encAddrLabel);
             }
             return false;
         }
         return true;
     } else if (millis() - encoderReadFailurePrintTime > 5000) {
         encoderReadFailurePrintTime = millis();
-        log_warn("Encoder read failure on " << encAddrLabel.c_str());
+        log_warn("Encoder read failure on " << encAddrLabel);
         //Maslow.panic();
     }
     return false;
@@ -203,8 +203,8 @@ bool MotorUnit::retract() {
     if (!pull_tight(Maslow.calibration.retractCurrentThreshold))
         return false;
 
-    String encAddrLabel = Maslow.axis_id_to_label(_encoderAddress);
-    log_info(encAddrLabel.c_str() << " pulled tight with offset " << getPosition());
+    const char* encAddrLabel = Maslow.axis_id_to_label(_encoderAddress);
+    log_info(encAddrLabel << " pulled tight with offset " << getPosition());
     zero();
 
     return true;

--- a/firmware/FluidNC/src/ProcessSettings.cpp
+++ b/firmware/FluidNC/src/ProcessSettings.cpp
@@ -811,7 +811,7 @@ static Error setReportInterval(const char* value, WebUI::AuthenticationLevel aut
 }
 
 static Error showHeap(const char* value, WebUI::AuthenticationLevel auth_level, Channel& out) {
-    log_info("Heap free: " << xPortGetFreeHeapSize() << " min: " << heapLowWater);
+    report_memory_diagnostics();
     return Error::Ok;
 }
 

--- a/firmware/FluidNC/src/Protocol.cpp
+++ b/firmware/FluidNC/src/Protocol.cpp
@@ -369,10 +369,13 @@ void     protocol_main_loop() {
             report_echo_line_received(activeLine, allChannels);
 #endif
 
+            Maslow.markActivity(activeLine);
             Error status_code = execute_line(activeLine, *activeChannel, WebUI::AuthenticationLevel::LEVEL_GUEST);
 
             // Tell the channel that the line has been processed.
+            Maslow.markActivity("ack");
             activeChannel->ack(status_code);
+            Maslow.markActivity("main loop");
 
             // Tell the input polling task that the line has been processed,
             // so it can give us another one when available
@@ -382,7 +385,9 @@ void     protocol_main_loop() {
         protocol_execute_realtime();  // Runtime command check point.
         // Auto-cycle start any queued moves.
         protocol_auto_cycle_start();
+        Maslow.markActivity("sys.process_changes");
         sys.process_changes();
+        Maslow.markActivity("stepper disable check");
 
         if (sys.abort()) {
             stop_polling();

--- a/firmware/FluidNC/src/Protocol.cpp
+++ b/firmware/FluidNC/src/Protocol.cpp
@@ -21,6 +21,7 @@
 #include "Settings.h"       // settings_execute_startup
 #include "Machine/LimitPin.h"
 #include "./Maslow/Maslow.h"
+#include <esp_heap_caps.h>
 
 volatile ExecAlarm rtAlarm;  // Global realtime executor bitflag variable for setting various alarms.
 
@@ -205,18 +206,31 @@ void stop_telemetry() {
     }
 }
 
-void start_telemetry() {
+// Create the telemetry task on demand.  Its stack is large (telemetry_loop
+// buffers samples before writing them to the SD card) and telemetry is off by
+// default, so the task is only created once telemetry is actually enabled.
+// Keeping it uncreated leaves that stack in the heap for the rest of the
+// firmware, which matters on the ESP32-S3 where free heap runs tight.
+void ensure_telemetry_task() {
     if (telemetryTask) {
         vTaskResume(telemetryTask);
-    } else {
-        xTaskCreatePinnedToCore(telemetry_loop,    // task
-                                "telemetry",       // name for task
-                                16000,             // size of task stack
-                                0,                 // parameters
-                                1,                 // priority
-                                &telemetryTask,    // task handle
-                                SUPPORT_TASK_CORE  // core
-        );
+        return;
+    }
+    xTaskCreatePinnedToCore(telemetry_loop,    // task
+                            "telemetry",       // name for task
+                            16000,             // size of task stack
+                            0,                 // parameters
+                            1,                 // priority
+                            &telemetryTask,    // task handle
+                            SUPPORT_TASK_CORE  // core
+    );
+}
+
+void start_telemetry() {
+    // Only resume an already-created task.  If telemetry has never been turned
+    // on there is no task to start; set_telemetry() creates it when needed.
+    if (telemetryTask) {
+        vTaskResume(telemetryTask);
     }
 }
 
@@ -310,6 +324,35 @@ static void check_startup_state() {
 const uint32_t heapWarnThreshold = 15000;
 
 uint32_t heapLowWater = UINT_MAX;
+
+// Distinguishes the three things that look identical from a bare free-heap number:
+//   - a leak            -> allocBlocks climbs and never comes back down
+//   - fragmentation     -> free stays flat but largestBlock shrinks
+//   - a legitimate peak -> both recover after the operation finishes
+// Stack numbers are the smallest free space each task has ever had; a value near
+// zero means that task is about to overflow its stack, which looks like a crash
+// rather than an allocation failure.
+void report_memory_diagnostics() {
+    multi_heap_info_t info;
+    heap_caps_get_info(&info, MALLOC_CAP_8BIT | MALLOC_CAP_INTERNAL);
+
+    log_info("Heap free: " << xPortGetFreeHeapSize() << " min: " << heapLowWater);
+    log_info("Heap largestBlock: " << info.largest_free_block << " allocBlocks: " << info.allocated_blocks
+                                   << " freeBlocks: " << info.free_blocks);
+
+    if (pollingTask) {
+        log_info("Stack free poller: " << uxTaskGetStackHighWaterMark(pollingTask));
+    }
+    if (outputTask) {
+        log_info("Stack free output: " << uxTaskGetStackHighWaterMark(outputTask));
+    }
+    if (telemetryTask) {
+        log_info("Stack free telemetry: " << uxTaskGetStackHighWaterMark(telemetryTask));
+    }
+    log_info("Stack free main: " << uxTaskGetStackHighWaterMark(nullptr));
+
+    allChannels.listChannelStats();
+}
 void     protocol_main_loop() {
     check_startup_state();
     start_polling();
@@ -367,7 +410,13 @@ void     protocol_main_loop() {
         if (newHeapSize < heapLowWater) {
             heapLowWater = newHeapSize;
             if (heapLowWater < heapWarnThreshold) {
-                log_warn("Low memory: " << heapLowWater << " bytes");
+                // Carry the block counts along with the free number.  Rising
+                // allocBlocks means something is leaking; a largestBlock far below
+                // the free total means the heap is fragmented rather than exhausted.
+                multi_heap_info_t info;
+                heap_caps_get_info(&info, MALLOC_CAP_8BIT | MALLOC_CAP_INTERNAL);
+                log_warn("Low memory: " << heapLowWater << " bytes largestBlock: " << info.largest_free_block
+                                        << " allocBlocks: " << info.allocated_blocks);
             }
         }
     }

--- a/firmware/FluidNC/src/Protocol.h
+++ b/firmware/FluidNC/src/Protocol.h
@@ -120,4 +120,13 @@ void send_line(Print& channel, const std::string& message);
 
 void drain_messages();
 
+// Creates the telemetry task if it does not exist yet, otherwise resumes it.
+// Called when telemetry is switched on so the task's stack is not allocated
+// on machines that never use telemetry.
+void ensure_telemetry_task();
+
+// Logs free heap, fragmentation, per-task stack headroom and per-channel input
+// backlog.  Backs the $Heap command.
+void report_memory_diagnostics();
+
 extern uint32_t heapLowWater;

--- a/firmware/FluidNC/src/Report.cpp
+++ b/firmware/FluidNC/src/Report.cpp
@@ -636,8 +636,8 @@ void report_realtime_status(Channel& channel) {
             }
         }
     }
-    if (InputFile::_progress.length()) {
-        msg << "|" + InputFile::_progress;
+    if (InputFile::_progress[0] != '\0') {
+        msg << "|" << InputFile::_progress;
         plan_block_t* cur_block = plan_get_current_block();
         if (cur_block != NULL && cur_block->file_line_number > 0) {
             msg << "," << cur_block->file_line_number;

--- a/firmware/FluidNC/src/Serial.cpp
+++ b/firmware/FluidNC/src/Serial.cpp
@@ -191,7 +191,13 @@ void AllChannels::init() {
 }
 
 void AllChannels::kill(Channel* channel) {
-    xQueueSend(_killQueue, &channel, 0);
+    // The kill queue is drained in pollLine().  If it is full the send fails
+    // silently and the channel is never deregistered nor deleted - it stays
+    // registered forever, holding its ~2KB of buffers.  Report it rather than
+    // losing the memory without a trace.
+    if (!xQueueSend(_killQueue, &channel, 0)) {
+        log_warn("Kill queue full; channel " << channel->name() << " not reclaimed");
+    }
 }
 
 void AllChannels::registration(Channel* channel) {
@@ -219,6 +225,18 @@ void AllChannels::listChannels(Channel& out) {
     for (auto channel : _channelq) {
         log_to(out, channel->name());
     }
+    _mutex.unlock();
+}
+
+void AllChannels::listChannelStats() {
+    _mutex.lock();
+    size_t total = 0;
+    for (auto channel : _channelq) {
+        const size_t queued = channel->queuedBytes();
+        total += queued;
+        log_info("  channel " << channel->name() << " queued=" << queued);
+    }
+    log_info("Channels: " << _channelq.size() << " totalQueued=" << total);
     _mutex.unlock();
 }
 

--- a/firmware/FluidNC/src/Serial.cpp
+++ b/firmware/FluidNC/src/Serial.cpp
@@ -210,13 +210,16 @@ void AllChannels::registrationFront(Channel* channel) {
     _channelq.insert(_channelq.begin(), channel);
     _mutex.unlock();
 }
-void AllChannels::deregistration(Channel* channel) {
+bool AllChannels::deregistration(Channel* channel) {
     _mutex.lock();
     if (channel == _lastChannel) {
         _lastChannel = nullptr;
     }
-    _channelq.erase(std::remove(_channelq.begin(), _channelq.end(), channel), _channelq.end());
+    auto it      = std::remove(_channelq.begin(), _channelq.end(), channel);
+    bool removed = it != _channelq.end();
+    _channelq.erase(it, _channelq.end());
     _mutex.unlock();
+    return removed;
 }
 
 void AllChannels::listChannels(Channel& out) {
@@ -296,10 +299,24 @@ size_t AllChannels::write(const uint8_t* buffer, size_t length) {
     return length;
 }
 Channel* AllChannels::pollLine(char* line) {
-    Channel* deadChannel;
+    // A channel can legitimately be killed more than once before the queue is
+    // drained.  A file job stopped by an alarm kills itself from stopJob(), and
+    // then the line that was already in flight acks with an error and kills it
+    // again from ack().  Deleting the same channel twice corrupts the heap; the
+    // fault surfaces later as a call through a clobbered vtable in a surviving
+    // channel.  Dedup the batch, and delete only what deregistration actually
+    // removed, so a stale pointer from an earlier drain is ignored.
+    Channel*              deadChannel;
+    std::vector<Channel*> deadChannels;
     while (xQueueReceive(_killQueue, &deadChannel, 0)) {
-        deregistration(deadChannel);
-        delete deadChannel;
+        if (std::find(deadChannels.begin(), deadChannels.end(), deadChannel) == deadChannels.end()) {
+            deadChannels.push_back(deadChannel);
+        }
+    }
+    for (auto channel : deadChannels) {
+        if (deregistration(channel)) {
+            delete channel;
+        }
     }
 
     // To avoid starving other channels when one has a lot

--- a/firmware/FluidNC/src/Serial.h
+++ b/firmware/FluidNC/src/Serial.h
@@ -98,6 +98,11 @@ public:
 
     void listChannels(Channel& out);
 
+    // Logs how many channels are registered and how much input each has buffered.
+    // A channel count that climbs over a session means channels are being created
+    // and not reclaimed; a climbing queue means input is outrunning the machine.
+    void listChannelStats();
+
     Channel* pollLine(char* line) override;
 
     void stopJob() override;

--- a/firmware/FluidNC/src/Serial.h
+++ b/firmware/FluidNC/src/Serial.h
@@ -85,7 +85,9 @@ public:
 
     void registration(Channel* channel);
     void registrationFront(Channel* channel);
-    void deregistration(Channel* channel);
+    // Returns true if the channel was registered and has now been removed.
+    // Callers that own the channel use this to decide whether to delete it.
+    bool deregistration(Channel* channel);
     void init();
 
     size_t write(uint8_t data) override;


### PR DESCRIPTION
This adds some extra constants in the config file which allow the math to compensate for stretch in the belts. Specifically it adds:

```
    beltAxialStiffness: 178900.000000
    sledWeight: 86.328003
    calibrationPullForce: 156.960007
```

As the machine moves to different positions the forces on the belts change resulting in some amount of stretch. The stretch is quite small, but we care about small inaccuracies so we should be taking it into account.