### PR TITLE
Move the Layout Simulator into the docs

### DIFF
--- a/docs/FrameLibrary.md
+++ b/docs/FrameLibrary.md
@@ -22,7 +22,7 @@ geertdoornbos has made a cool one where you can simulate the movement of the rob
 <https://maslowcnc.nl/frame>
 
 Bar's frame simulator here: 
-<https://maslowcnc.github.io/Layout-Simulator/>
+[Layout Simulator](layout-simulator/) ([documentation](layout-simulator/README.md))
 
 Bar's Calibration point tester:
 <https://barboursmith.github.io/Calibration-Simulation/>

--- a/docs/QuickStart.md
+++ b/docs/QuickStart.md
@@ -33,7 +33,7 @@ You can find a complete list of different anchor types here: [ADD LINK]
 
 <img width="500" alt="image" src="https://github.com/user-attachments/assets/8e36c830-4d37-4d99-a702-d1638e9ebba6" />
 
-We've put together a tool to help you to better understand what size of frame you might want and how that will impact your cutting area. You can find that tool here: https://maslowcnc.github.io/Layout-Simulator/
+We've put together a tool to help you to better understand what size of frame you might want and how that will impact your cutting area. You can find that tool here: [Layout Simulator](layout-simulator/).
 
 <img src="quick-start/images/Layout%20Simulator.png" alt="Layout Simulator" width="600">
 

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -59,7 +59,7 @@ geertdoornbos has made a cool one where you can simulate the movement of the rob
 <https://maslowcnc.nl/frame>
 
 Bar's frame simulator here: 
-<https://maslowcnc.github.io/Layout-Simulator/>
+[Layout Simulator](layout-simulator/) ([documentation](layout-simulator/README.md))
 
 Bar's Calibration point tester:
 <https://barboursmith.github.io/Calibration-Simulation/>

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -44,6 +44,7 @@ readme_index:
 include:
   - _config.yml
   - calibration-simulation
+  - layout-simulator
 
 # Exclude build artifacts
 exclude:

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,6 +43,8 @@ Step-by-step instructions for building your Maslow 4:
 - [Calibration Data Parser](calibration-simulation/data-parser.html) - Analyze real calibration data with the machine's exact solver, and visualize which measurements are causing errors
   - [Data Parser Documentation](calibration-simulation/DATA-PARSER.md)
 - [Manual Anchor Locator](manual-anchor-locator/) - Compute anchor coordinates and estimate measurement error from four side lengths and two diagonals
+- [Layout Simulator](layout-simulator/) - Try an anchor spacing and see how much of the area inside it Maslow can cut well
+  - [Layout Simulator Documentation](layout-simulator/README.md)
 
 ## Contributing
 

--- a/docs/layout-simulator/LICENSE
+++ b/docs/layout-simulator/LICENSE
@@ -1,0 +1,674 @@
+GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/docs/layout-simulator/README.md
+++ b/docs/layout-simulator/README.md
@@ -1,0 +1,67 @@
+# Layout Simulator
+
+Interactive tool for choosing anchor point spacing. It shades the area inside your
+four anchors to show where Maslow 4 can be expected to cut well, and where cut
+quality will start to degrade.
+
+**[Open the Layout Simulator](index.html)**
+
+## Why you want it
+
+The usable cutting area is always smaller than the rectangle formed by your four
+anchor points. How much smaller depends on the spacing you choose. This tool lets
+you try a frame size before you build it, so you can check that the material you
+intend to cut actually fits inside the good-quality region.
+
+## Using it
+
+1. Enter the **Height** and **Width** of your anchor point spacing, in millimeters
+   (measured center-to-center between anchors). Values are capped at 5000 mm.
+2. Enter the **Work Area Width** and **Work Area Height** of the material you plan
+   to cut. The default is a 2438 x 1219 mm sheet (4x8 foot). This rectangle is drawn
+   in the frame so you can see whether it lands inside the good region.
+3. Adjust the **Resolution** slider to trade off between a finer grid and faster
+   redraws.
+4. Toggle the criteria checkboxes to see which one is limiting a given area.
+
+Drag to pan and scroll to zoom the canvas.
+
+## The four criteria
+
+Each checkbox turns one limit on or off in the color coding. Hovering over a
+checkbox in the tool shows the same explanation.
+
+- **Belt Angle** - As the sled approaches an anchor point, the angle from the machine
+  to that anchor gets more aggressive, which leads to accuracy problems.
+- **Arm Contact** - The arms can only rotate so far before they contact the machine's
+  uprights. The angle between adjacent arms has to stay between roughly 20 and 130
+  degrees, and the angle between opposite arms has to stay above roughly 130 degrees.
+- **Belt Tension** - In vertical orientation, tension in the upper belts approaches
+  infinity as the sled moves directly between the two upper anchors.
+- **Belt Length** - The belts are finite. Out of the box they cannot reach further
+  than about 4419 mm (14.5 feet) from an anchor.
+
+Areas are shaded from green (good) through yellow to red (expect trouble). Red does
+not necessarily mean the machine will refuse to move there, it means accuracy and
+reliability will suffer.
+
+## Related
+
+- [Frame Library](../FrameLibrary.md) - Frame designs, anchor requirements, and other
+  frame calculators
+- [Quick Start Guide](../QuickStart.md) - Choosing anchors and setting up your frame
+- [Calibration Simulator](../calibration-simulation/) - Simulates the calibration
+  process rather than the cutting area
+- [Manual Anchor Locator](../manual-anchor-locator/) - Compute anchor coordinates from
+  tape measure readings
+
+## Provenance
+
+This tool previously lived in its own repository at
+[MaslowCNC/Layout-Simulator](https://github.com/MaslowCNC/Layout-Simulator) and was
+published at `https://maslowcnc.github.io/Layout-Simulator/`. It has been moved here
+so that it lives alongside the rest of the Maslow 4 documentation. It is licensed
+under the GPL-3.0, see [LICENSE](LICENSE).
+
+The color gradient helper is by Michele Locati and is used under the MIT license
+(<https://gist.github.com/mlocati/7210513>).

--- a/docs/layout-simulator/index.html
+++ b/docs/layout-simulator/index.html
@@ -1,0 +1,507 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Anchor Point Layout Simulator</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            background-color: #f4f4f4;
+            margin: 0;
+            padding: 20px;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 100vh;
+        }
+        canvas {
+            border: 1px solid #ccc;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        }
+        .controls {
+            display: inline-block;
+            vertical-align: top;
+            margin-left: 20px;
+            background-color: #fff;
+            padding: 20px;
+            border-radius: 8px;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        }
+        .controls label {
+            display: block;
+            margin-bottom: 5px;
+            font-weight: bold;
+        }
+        .controls input[type="text"],
+        .controls input[type="range"] {
+            display: block;
+            margin-bottom: 15px;
+            width: 100%;
+            padding: 8px;
+            border: 1px solid #ccc;
+            border-radius: 4px;
+        }
+        .checkbox-container {
+            display: flex;
+            align-items: center;
+            margin-bottom: 15px;
+        }
+        .checkbox-container label {
+            margin-right: 10px;
+            font-weight: normal;
+        }
+        .checkbox-container input[type="checkbox"] {
+            transform: scale(1.2);
+        }
+        .controls .back-link {
+            display: block;
+            margin-bottom: 15px;
+            font-size: 0.9em;
+            text-decoration: none;
+            color: #1d5b4f;
+        }
+        .controls .back-link:hover {
+            text-decoration: underline;
+        }
+    </style>
+</head>
+<body>
+    <canvas id="myCanvas" width="1000" height="900"></canvas>
+    <div class="controls">
+        <a class="back-link" href="../">&larr; Maslow 4 Documentation</a>
+        <p>
+            This tool is designed to help you to understand how large of an area Maslow4 can reasonably cut inside of for a given anchor spacing. <br><br>
+            Enter the height and width of your anchor point spacing to see the area in which the cut quality will be best. <br><br>
+            You can turn on and off different criteria for color coding or hover over each option for a description of what it is.
+        </p>
+        <label for="heightInput">Height:</label>
+        <input type="text" id="heightInput" value="3300" oninput="updateDimensions()">
+        <label for="widthInput">Width:</label>
+        <input type="text" id="widthInput" value="4000" oninput="updateDimensions()">
+        <label for="resolutionSlider">Resolution:</label>
+        <input type="range" id="resolutionSlider" min="10" max="100" value="20" oninput="updateResolution(this.value)">
+        
+        <div class="checkbox-container" title="As the sled approaches the anchor point the angle from the machine to the anchor point gets more aggressive which can lead to issues.">
+            <label for="beltAngleCheckbox">Belt Angle:</label>
+            <input type="checkbox" id="beltAngleCheckbox" checked onchange="updateBeltAngle(this.checked)">
+        </div>
+        <div class="checkbox-container" title="There is a limit to how far the arms can rotate before they contact the machine which reduces acuracy.">
+            <label for="armContactCheckbox">Arm Contact:</label>
+            <input type="checkbox" id="armContactCheckbox" checked onchange="updateArmContact(this.checked)">
+        </div>
+        <div class="checkbox-container" title = "In vertical orientation the tension in the upper belts approaces infintiy as the sled moves directly between them.">
+            <label for="beltTensionCheckbox">Belt Tension:</label>
+            <input type="checkbox" id="beltTensionCheckbox" checked onchange="updateBeltTension(this.checked)">
+        </div>
+        <div class="checkbox-container" title="The length of the belt is finite and cannot reach further.">
+            <label for="beltLengthCheckbox">Belt Length:</label>
+            <input type="checkbox" id="beltLengthCheckbox" checked onchange="updateBeltLength(this.checked)">
+        </div>
+
+        <label for="workAreaWidthInput">Work Area Width:</label>
+        <input type="text" id="workAreaWidthInput" value="2438" oninput="updateWorkAreaDimensions()">
+        <label for="workAreaHeightInput">Work Area Height:</label>
+        <input type="text" id="workAreaHeightInput" value="1219" oninput="updateWorkAreaDimensions()">
+    </div>
+    <script>
+        var canvas = document.getElementById('myCanvas');
+        var tp = canvas.getContext('2d');
+        var tpBbox = { min: { x: Infinity, y: Infinity }, max: { x: -Infinity, y: -Infinity } };
+        var bboxIsSet = false;
+
+        var tlX = 0;
+        var tlY = 3300;
+        var trX = 4000; 
+        var trY = 3300;
+        var blX = 0;
+        var blY = 0;
+        var brX = 4000;
+        var brY = 0;
+
+        var tlZ = 100;
+        var trZ = 56;
+        var blZ = 34;
+        var brZ = 78;
+
+        var scale = .25;
+        var panX = 0;
+        var panY = 0;
+        var isPanning = false;
+        var startX, startY;
+
+        var resolution = 20;
+
+        var beltAngle = true;
+        var armContact = true;
+        var beltTension = true;
+        var beltLength = true;
+
+        var woodWidth = 2438;
+        var woodHeight = 2438 / 2;
+
+        function updateDimensions() {
+            var height = document.getElementById('heightInput').value;
+            var width = document.getElementById('widthInput').value;
+            if (height && width) {
+                let h = parseInt(height);
+                let w = parseInt(width);
+
+                h = Math.min(5000, h);
+                w = Math.min(5000, w);
+                tlY = h;
+                trX = w;
+                trY = h;
+                brX = w;
+                draw();
+            }
+        }
+
+        function updateWorkAreaDimensions() {
+            console.log("Updating work area dimensions");
+            var height = document.getElementById('workAreaHeightInput').value;
+            var width = document.getElementById('workAreaWidthInput').value;
+            if (height && width) {
+                console.log("Width and height are defined");
+                woodHeight = parseInt(height);
+                woodWidth = parseInt(width);
+                draw();
+            }
+        }
+
+        function updateResolution(value) {
+            resolution = value;
+            draw();
+        }
+
+        function updateBeltAngle(checked) {
+            beltAngle = checked;
+            draw();
+        }
+
+        function updateArmContact(checked) {
+            armContact = checked;
+            draw();
+        }
+
+        function updateBeltTension(checked) {
+            beltTension = checked;
+            draw();
+        }
+
+        function updateBeltLength(checked) {
+            beltLength = checked;
+            draw();
+        }
+
+        //Shifts 0,0 to be the center of the canvas and scales the points for zooming
+        function projection(point) {
+            return { x: point.x * scale + canvas.width / 2 + panX, y: -point.y * scale + canvas.height / 2 + panY };
+        }
+
+        // This is the inverse of projection, it shifts a point from the canvas to the original coordinate system
+        function inverseProjection(point) {
+            return { x: (point.x - canvas.width / 2 - panX) / scale, y: -(point.y - canvas.height / 2 - panY) / scale };
+        }
+
+        function draw() {
+            tp.clearRect(0, 0, canvas.width, canvas.height);
+            drawMachineBounds();
+            drawMachineBelts();
+        }
+
+        var drawMachineBounds = function() {
+
+            const p0 = projection({ x: -woodWidth / 2, y: -woodHeight / 2, z: 0 });
+            const p1 = projection({ x: woodWidth / 2, y: -woodHeight / 2, z: 0 });
+            const p2 = projection({ x: woodWidth / 2, y: woodHeight / 2, z: 0 });
+            const p3 = projection({ x: -woodWidth / 2, y: woodHeight / 2, z: 0 });
+
+            tpBbox.min.x = Math.min(tpBbox.min.x, p0.x);
+            tpBbox.min.y = Math.min(tpBbox.min.y, p0.y);
+            tpBbox.max.x = Math.max(tpBbox.max.x, p2.x);
+            tpBbox.max.y = Math.max(tpBbox.max.y, p2.y);
+            bboxIsSet = true;
+
+            tp.beginPath();
+            tp.moveTo(p0.x, p0.y);
+            tp.lineTo(p1.x, p1.y);
+            tp.lineTo(p2.x, p2.y);
+            tp.lineTo(p3.x, p3.y);
+            tp.lineTo(p0.x, p0.y);
+            tp.strokeStyle = "green";
+            tp.stroke();
+        }
+
+        var drawMachineBelts = function() {
+
+            const tl = projection({x: tlX - trX/2, y: tlY/2, z: 0});
+            const tr = projection({x: trX/2, y: trY/2, z: 0});
+            const bl = projection({x: blX - brX/2, y: blY - tlY/2, z: 0});
+            const br = projection({x: brX/2, y: brY - trY/2, z: 0});
+
+            tpBbox.min.x = Math.min(tpBbox.min.x, bl.x);
+            tpBbox.min.y = Math.min(tpBbox.min.y, bl.y);
+            tpBbox.max.x = Math.max(tpBbox.max.x, tr.x);
+            tpBbox.max.y = Math.max(tpBbox.max.y, tr.y);
+
+            //Find the center
+            let c = projection({x: 0, y: 0, z: 0});
+
+            tp.beginPath();
+            tp.strokeStyle = "grey";
+            tp.moveTo(c.x, c.y);
+            tp.lineTo(tl.x, tl.y);
+            tp.moveTo(c.x, c.y);
+            tp.lineTo(tr.x, tr.y);
+            tp.moveTo(c.x, c.y);
+            tp.lineTo(bl.x, bl.y);
+            tp.moveTo(c.x, c.y);
+            tp.lineTo(br.x, br.y);
+            tp.stroke();
+
+            tp.fillStyle = "black";
+            tp.beginPath();
+            tp.arc(tl.x, tl.y, 10, 0, 2 * Math.PI);
+            tp.closePath();
+            tp.fill();
+            tp.beginPath();
+            tp.arc(tr.x, tr.y, 10, 0, 2 * Math.PI);
+            tp.closePath();
+            tp.fill();
+            tp.beginPath();
+            tp.arc(br.x, br.y, 10, 0, 2 * Math.PI);
+            tp.closePath();
+            tp.fill();
+            tp.beginPath();
+            tp.arc(bl.x, bl.y, 10, 0, 2 * Math.PI);
+            tp.closePath();
+            tp.fill();
+
+            const squareSize = resolution * scale;
+
+            //drawARect(tl.x, tl.y, squareSize, computePositionGradient(0, 0, tl, tr, bl, br));
+
+            var i = bl.x;
+            var j = -1*bl.y;
+            while (i <= tr.x) {
+                while (j <= -1*tr.y) {
+                    drawARect(i, -1*j, squareSize, computePositionGradient(i, j, tl, tr, bl, br));
+                    j = j + squareSize;
+                }
+                j = -1*bl.y;
+                i = i + squareSize;
+            }
+        }
+
+        var checkMinBeltLength = function(x1, y1, x2, y2, height) {
+
+            const dist = Math.sqrt((x1 - x2) * (x1 - x2) + (y1 - y2) * (y1 - y2));
+
+            //Hitting the sled
+            if (dist < 100){
+                return 100;
+            }
+
+            if(beltLength){
+                //The belt can't go any further than 14.5 feet or 4419 mm
+                if (dist > 4419){
+                    return 100;
+                }
+            }
+
+            //Compute the angle over the distance
+            const angle = Math.asin(height / dist);
+
+            if (angle > .1) {
+                return 5*angle;
+            } else {
+                return 0;
+            }
+        }
+
+        var checkAnglesBetweenBelts = function(x, y, tl, tr, bl, br) {
+
+            //The dist between tl and tr
+            const a = Math.sqrt((tl.x - tr.x) * (tl.x - tr.x) + (tl.y - tr.y) * (tl.y - tr.y));
+            //The dist between tl and x,y
+            const b = Math.sqrt((tl.x - x) * (tl.x - x) + (tl.y - y) * (tl.y - y));
+            //The dist between tr and x,y
+            const c = Math.sqrt((tr.x - x) * (tr.x - x) + (tr.y - y) * (tr.y - y));
+
+            //Angle between x,y to tl and x,y to tr -- Calculate the angle opposite to side a
+            const topAngle = Math.acos((b*b + c*c - a*a) / (2 * b * c)) * (180 / Math.PI);
+
+            //Repeat for the left side
+            const d = Math.sqrt((tl.x - bl.x) * (tl.x - bl.x) + (tl.y - bl.y) * (tl.y - bl.y));
+            const e = Math.sqrt((tl.x - x) * (tl.x - x) + (tl.y - y) * (tl.y - y));
+            const f = Math.sqrt((bl.x - x) * (bl.x - x) + (bl.y - y) * (bl.y - y));
+
+            const leftAngle = Math.acos((e*e + f*f - d*d) / (2 * e * f)) * (180 / Math.PI);
+
+            //Repeat for the right side
+            const g = Math.sqrt((tr.x - br.x) * (tr.x - br.x) + (tr.y - br.y) * (tr.y - br.y));
+            const h = Math.sqrt((tr.x - x) * (tr.x - x) + (tr.y - y) * (tr.y - y));
+            const i = Math.sqrt((br.x - x) * (br.x - x) + (br.y - y) * (br.y - y));
+
+            const rightAngle = Math.acos((h*h + i*i - g*g) / (2 * h * i)) * (180 / Math.PI);
+
+            //And the bottom
+            const j = Math.sqrt((bl.x - br.x) * (bl.x - br.x) + (bl.y - br.y) * (bl.y - br.y));
+            const k = Math.sqrt((bl.x - x) * (bl.x - x) + (bl.y - y) * (bl.y - y));
+            const l = Math.sqrt((br.x - x) * (br.x - x) + (br.y - y) * (br.y - y));
+
+            const bottomAngle = Math.acos((k*k + l*l - j*j) / (2 * k * l)) * (180 / Math.PI);
+
+            // Now we need to compute the minimum angle for the opposite sides. This can't be less than 130 degrees
+
+            // Angle between x,y to tl and x,y to br
+            const vector1 = { x: tl.x - x, y: tl.y - y };
+            const vector2 = { x: br.x - x, y: br.y - y };
+
+            const dotProduct = vector1.x * vector2.x + vector1.y * vector2.y;
+            const magnitude1 = Math.sqrt(vector1.x * vector1.x + vector1.y * vector1.y);
+            const magnitude2 = Math.sqrt(vector2.x * vector2.x + vector2.y * vector2.y);
+
+            const tlbr = Math.acos(dotProduct / (magnitude1 * magnitude2)) * (180 / Math.PI);
+
+            // Angle between x,y to tr and x,y to bl
+            const vector3 = { x: tr.x - x, y: tr.y - y };
+            const vector4 = { x: bl.x - x, y: bl.y - y };
+
+            const dotProduct2 = vector3.x * vector4.x + vector3.y * vector4.y;
+            const magnitude3 = Math.sqrt(vector3.x * vector3.x + vector3.y * vector3.y);
+            const magnitude4 = Math.sqrt(vector4.x * vector4.x + vector4.y * vector4.y);
+
+            const trbl = Math.acos(dotProduct2 / (magnitude3 * magnitude4)) * (180 / Math.PI);
+
+            const maxAngle = Math.max(topAngle, leftAngle, rightAngle, bottomAngle);
+            const minAngle = Math.min(topAngle, leftAngle, rightAngle, bottomAngle);
+            const minOpposite = Math.min(tlbr, trbl);
+
+            let minAngleVal    = 0;
+            let maxAngleVal    = 0;
+            let minOppositeVal = 0;
+
+            //The minimum allowable angle between opposite arms is 130 degrees or 2.26 radians
+            if(minOpposite < 130){
+                minOppositeVal = .009*(130-minAngle);
+            }
+
+            //The minimum allowable angle is 20 degrees or .35 radians between adjacent arms
+            if(minAngle < 20){
+                minAngleVal =  4*(20-minAngle);
+            }
+
+            //The maximum allowable angle between adjacent arms is is 130 degress or 2.26 radians
+            if(maxAngle > 130){
+                maxAngleVal =  .004*maxAngle;
+            }
+            
+            return Math.max(minAngleVal, maxAngleVal, minOppositeVal);
+        }
+
+        var computePositionGradient = function(x, y, tl, tr, bl, br) {
+            var opacity = 0;
+
+            let posI = inverseProjection({x: x, y: -1*y}); //This is where the calculation is being done
+            let tlI = inverseProjection(tl);
+            let trI = inverseProjection(tr);
+            let blI = inverseProjection(bl);
+            let brI = inverseProjection(br);
+
+            if(beltAngle){
+                opacity = opacity + checkMinBeltLength(posI.x, posI.y, tlI.x, tlI.y, tlZ);
+                opacity = opacity + checkMinBeltLength(posI.x, posI.y, trI.x, trI.y, trZ);
+                opacity = opacity + checkMinBeltLength(posI.x, posI.y, blI.x, blI.y, blZ);
+                opacity = opacity + checkMinBeltLength(posI.x, posI.y, brI.x, brI.y, brZ);
+            }
+
+            if(beltTension){
+                opacity = Math.max(opacity, computeTension(posI.x, posI.y, tlI, trI, blI, brI));
+            }
+
+            if(armContact){
+                opacity = Math.max(opacity, checkAnglesBetweenBelts(posI.x, posI.y, tlI, trI, blI, brI));
+            }
+
+            return opacity;
+        }
+
+        var computeTension = function(x,y, tl, tr, bl, br){
+            const A = Math.atan((y-tl.y)/(tr.x - x));
+            const B = Math.atan((y-tl.y)/(x-tl.x));
+
+            const T1 = 1 / (Math.cos(A) * Math.sin(B) / Math.cos(B) + Math.sin(A));
+            const T2 = 1 / (Math.cos(B) * Math.sin(A) / Math.cos(A) + Math.sin(B));
+
+            const T1Scaled = T1/-3;
+            const T2Scaled = T2/-3; //This is some arbitrary scaling to make it look right in terms of color
+
+            const max = Math.max(T1Scaled, T2Scaled);
+
+            if(max > .15){
+                return max;
+            }
+            else{
+                return 0;
+            }
+        }
+
+
+        // License: MIT - https://opensource.org/licenses/MIT
+        // Author: Michele Locati <michele@locati.it>
+        // Source: https://gist.github.com/mlocati/7210513
+        var perc2color = function(perc) {
+            var r, g, b = 0;
+            if(perc < 50) {
+                r = 255;
+                g = Math.round(5.1 * perc);
+            }
+            else {
+                g = 255;
+                r = Math.round(510 - 5.10 * perc);
+            }
+            var h = r * 0x10000 + g * 0x100 + b * 0x1;
+
+            //onsole.log(r + " " + g + " " + b)
+            return "rgba("+r+", "+g+", "+b+", .3)";//'#' + ('000000' + h.toString(16)).slice(-6);
+        }
+
+        var drawARect = function(x, y, size, opacity) {
+            tp.beginPath();
+            tp.fillStyle = perc2color(100 - 100 * opacity);
+            tp.rect(x - size / 2, y - size / 2, size, size); // Invert y-coordinate
+            tp.fill();
+        }
+
+        canvas.addEventListener('mousedown', function(e) {
+            isPanning = true;
+            startX = e.clientX - panX;
+            startY = e.clientY - panY;
+        });
+
+        canvas.addEventListener('mousemove', function(e) {
+            if (isPanning) {
+                panX = e.clientX - startX;
+                panY = e.clientY - startY;
+                draw();
+            }
+        });
+
+        canvas.addEventListener('mouseup', function() {
+            isPanning = false;
+        });
+
+        canvas.addEventListener('wheel', function(e) {
+            e.preventDefault();
+            var scaleAmount = e.deltaY * -0.002;
+            scale += scaleAmount;
+            scale = Math.min(Math.max(.125, scale), 4);
+            draw();
+        });
+
+        draw();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## What

Moves the anchor point Layout Simulator out of its own repository ([MaslowCNC/Layout-Simulator](https://github.com/MaslowCNC/Layout-Simulator), published at `maslowcnc.github.io/Layout-Simulator`) and into `docs/layout-simulator/`, then repoints the documentation at the local copy.

## Why

Three pages in these docs already linked out to the tool. Bringing it in-repo puts it next to the calibration simulator and the manual anchor locator, so it is versioned, reviewed, and edited alongside the documentation that references it.

## Contents

**New — `docs/layout-simulator/`**

- `index.html` — the tool, taken verbatim from `Layout-Simulator@main`, with one addition: a small "← Maslow 4 Documentation" back-link in the controls panel, matching the convention in `manual-anchor-locator`.
- `README.md` — new documentation page: what the tool is for, how to use it, and what each of the four criteria it color codes on means (belt angle, arm contact, belt tension, belt length), plus cross-links to the sibling tools and a provenance/license note.
- `LICENSE` — the GPL-3.0 text carried over from the source repository.

**Links updated**

| File | Change |
| --- | --- |
| `docs/index.md` | New entry under **Interactive Tools** |
| `docs/FrameLibrary.md` | "Bar's frame simulator" under *Frame calculators* now points locally |
| `docs/Troubleshooting.md` | Same link under *Frame Dimensions appropriate for your workspace* |
| `docs/QuickStart.md` | The frame-sizing tool callout now points locally |
| `docs/_config.yml` | `layout-simulator` added to the Jekyll `include` list, alongside `calibration-simulation` |

No remaining references to `maslowcnc.github.io/Layout-Simulator` outside the provenance note in the new README.

## Testing

Opened `docs/layout-simulator/index.html` in a browser. The canvas renders, the color coding computes, and there are no console errors.

## Notes for the reviewer

- **This takes `Layout-Simulator@main`, not the `copilot/add-minimum-angles-display` branch.** That branch is unmerged upstream and adds a live readout of vertical/horizontal minimum angles and their sines (+52 lines). `main` is what the docs were linking to, so that is what moved. Happy to fold the branch in if it should come along.
- **The old repository and URL are untouched.** `https://maslowcnc.github.io/Layout-Simulator/` still works, so existing forum links do not break. Archiving `MaslowCNC/Layout-Simulator` with a README pointer to the new location would be a sensible follow-up in that repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
