### PR TITLE
Fix Z probe retract jog sending ZNaN

### DIFF
--- a/ESP3D-WEBUI/www/js/grbl.js
+++ b/ESP3D-WEBUI/www/js/grbl.js
@@ -694,7 +694,9 @@ function grblGetProbeResult(response) {
         finalize_probing()
       }
     } else {
-      probe_failed_notification()
+      probe_alarm_suppress = true;
+      probe_failed_notification("Probe connection failed");
+      SendPrinterCommand("$X", true, null, null, 114, 1);
     }
   }
 }
@@ -867,6 +869,10 @@ const grblHandleMessage = (msg) => {
         return;
       }
       probe_failed_notification();
+    }
+    if (valueStartsWith(msg, ["ALARM:"]) && probe_alarm_suppress) {
+      SendPrinterCommand("$X", true, null, null, 114, 1);
+      return;
     }
     if (grbl_error_msg.length === 0) {
       grbl_error_msg = translate_text_item(msg.trim());

--- a/ESP3D-WEBUI/www/js/grbl.js
+++ b/ESP3D-WEBUI/www/js/grbl.js
@@ -693,7 +693,7 @@ function grblGetProbeResult(response) {
         SendPrinterCommand(cmd, true, null, null, 0, 1)
         finalize_probing()
       }
-    } else {
+    } else if (!probe_alarm_suppress) {
       probe_alarm_suppress = true;
       probe_failed_notification("Probe connection failed");
       SendPrinterCommand("$X", true, null, null, 114, 1);

--- a/ESP3D-WEBUI/www/js/grbl.js
+++ b/ESP3D-WEBUI/www/js/grbl.js
@@ -3,7 +3,6 @@
 
 var interval_status = -1
 var probe_progress_status = 0
-var probe_alarm_suppress = false
 var grbl_error_msg = ''
 var WCO = undefined
 var OVR = { feed: undefined, rapid: undefined, spindle: undefined }
@@ -556,7 +555,7 @@ const updateMaslowActionButton = () => {
 
 const show_grbl_status = (stateName = "", message = "", hasSD = false) => {
   setHTML("grbl_status_text", translate_text_item(message))
-  setClickability("clear_status_btn", stateName === "Alarm" && !probe_alarm_suppress);
+  setClickability("clear_status_btn", stateName === "Alarm");
 
   if (!stateName) {
     return;
@@ -566,13 +565,10 @@ const show_grbl_status = (stateName = "", message = "", hasSD = false) => {
   // Set systemStatus for tablet view (will be updated with progress by show_grbl_SD if file is running)
   setHTML("systemStatus", stateName);
 
-  if (stateName === "Alarm" && !probe_alarm_suppress) {
+  if (stateName === "Alarm") {
     id("systemStatus").classList.add("system-status-alarm");
   } else {
     id("systemStatus").classList.remove("system-status-alarm");
-    if (stateName !== "Alarm") {
-      probe_alarm_suppress = false;
-    }
   }
 
   const clickable = clickableFromStateName(stateName, hasSD);
@@ -688,15 +684,20 @@ function grblGetProbeResult(response) {
     const status = tab1[2].replace(']', '')
     if (Number.parseInt(status.trim()) === 1) {
       if (probe_progress_status !== 0) {
-        const cmd =
-          `$J=G90 G21 F1000 Z${getValueFloat("grblpanel_probetouchplatethickness") + getValueFloat("grblpanel_proberetract")}`
-        SendPrinterCommand(cmd, true, null, null, 0, 1)
+        // The probe was sent as G38.2 ... P<plate thickness>, so the firmware has already
+        // offset the work coordinate system: work Z at the contact point is the plate
+        // thickness.  Retracting to thickness + retract distance therefore lifts the bit
+        // exactly `retract` mm above the top of the plate.
+        // Use the values StartProbeProcess() validated and sent rather than re-reading the
+        // input fields, so the retract always matches the P word that was probed with.
+        const retractZ = probeValues.plateThickness.value + probeValues.retract.value
+        if (Number.isFinite(retractZ)) {
+          SendPrinterCommand(`$J=G90 G21 F1000 Z${retractZ}`, true, null, null, 0, 1)
+        }
         finalize_probing()
       }
-    } else if (!probe_alarm_suppress) {
-      probe_alarm_suppress = true;
-      probe_failed_notification("Probe connection failed");
-      SendPrinterCommand("$X", true, null, null, 114, 1);
+    } else {
+      probe_failed_notification()
     }
   }
 }
@@ -862,17 +863,7 @@ const grblHandleMessage = (msg) => {
   }
   if (valueStartsWith(msg, ["error:", "ALARM:", "Hold:", "Door:"])) {
     if (probe_progress_status !== 0) {
-      if (valueStartsWith(msg, ["ALARM:"])) {
-        probe_alarm_suppress = true;
-        probe_failed_notification("Probe connection failed");
-        SendPrinterCommand("$X", true, null, null, 114, 1);
-        return;
-      }
       probe_failed_notification();
-    }
-    if (valueStartsWith(msg, ["ALARM:"]) && probe_alarm_suppress) {
-      SendPrinterCommand("$X", true, null, null, 114, 1);
-      return;
     }
     if (grbl_error_msg.length === 0) {
       grbl_error_msg = translate_text_item(msg.trim());
@@ -886,14 +877,14 @@ const grblHandleMessage = (msg) => {
 };
 
 const checkProbeValue = (pv) => {
-  if (!("value" in pv)) {
-    if (pv.valType === "int" && typeof getValueInt === "function") {
-      pv.value = getValueInt(pv.fldId);
-    } else if (pv.valType === "float" && typeof getValueFloat === "function") {
-      pv.value = getValueFloat(pv.fldId);
-    } else {
-      return;
-    }
+  // Always re-read the field: the value is edited between probes, and a previously
+  // rejected (NaN) value must not stick around and block every later probe.
+  if (pv.valType === "int" && typeof getValueInt === "function") {
+    pv.value = getValueInt(pv.fldId);
+  } else if (pv.valType === "float" && typeof getValueFloat === "function") {
+    pv.value = getValueFloat(pv.fldId);
+  } else {
+    return;
   }
   if (Number.isNaN(pv.value) || pv.value > pv.maxVal || pv.value < pv.minVal) {
     alertdlgOOR(pv.valTitle, pv.minVal, pv.maxVal, pv.units);

--- a/ESP3D-WEBUI/www/js/grbl.js
+++ b/ESP3D-WEBUI/www/js/grbl.js
@@ -555,7 +555,7 @@ const updateMaslowActionButton = () => {
 
 const show_grbl_status = (stateName = "", message = "", hasSD = false) => {
   setHTML("grbl_status_text", translate_text_item(message))
-  setClickability("clear_status_btn", stateName === "Alarm");
+  setClickability("clear_status_btn", stateName === "Alarm" && probe_progress_status === 0);
 
   if (!stateName) {
     return;
@@ -565,7 +565,7 @@ const show_grbl_status = (stateName = "", message = "", hasSD = false) => {
   // Set systemStatus for tablet view (will be updated with progress by show_grbl_SD if file is running)
   setHTML("systemStatus", stateName);
 
-  if (stateName === "Alarm") {
+  if (stateName === "Alarm" && probe_progress_status === 0) {
     id("systemStatus").classList.add("system-status-alarm");
   } else {
     id("systemStatus").classList.remove("system-status-alarm");

--- a/ESP3D-WEBUI/www/js/grbl.js
+++ b/ESP3D-WEBUI/www/js/grbl.js
@@ -685,7 +685,7 @@ function grblGetProbeResult(response) {
     if (Number.parseInt(status.trim()) === 1) {
       if (probe_progress_status !== 0) {
         const cmd =
-          `$J=G90 G21 F1000 Z${getValueFloat("probetouchplatethickness") + getValueFloat("grblpanel_proberetract")}`
+          `$J=G90 G21 F1000 Z${getValueFloat("grblpanel_probetouchplatethickness") + getValueFloat("grblpanel_proberetract")}`
         SendPrinterCommand(cmd, true, null, null, 0, 1)
         finalize_probing()
       }

--- a/ESP3D-WEBUI/www/js/grbl.js
+++ b/ESP3D-WEBUI/www/js/grbl.js
@@ -3,6 +3,7 @@
 
 var interval_status = -1
 var probe_progress_status = 0
+var probe_alarm_suppress = false
 var grbl_error_msg = ''
 var WCO = undefined
 var OVR = { feed: undefined, rapid: undefined, spindle: undefined }
@@ -555,7 +556,7 @@ const updateMaslowActionButton = () => {
 
 const show_grbl_status = (stateName = "", message = "", hasSD = false) => {
   setHTML("grbl_status_text", translate_text_item(message))
-  setClickability("clear_status_btn", stateName === "Alarm" && probe_progress_status === 0);
+  setClickability("clear_status_btn", stateName === "Alarm" && !probe_alarm_suppress);
 
   if (!stateName) {
     return;
@@ -565,10 +566,13 @@ const show_grbl_status = (stateName = "", message = "", hasSD = false) => {
   // Set systemStatus for tablet view (will be updated with progress by show_grbl_SD if file is running)
   setHTML("systemStatus", stateName);
 
-  if (stateName === "Alarm" && probe_progress_status === 0) {
+  if (stateName === "Alarm" && !probe_alarm_suppress) {
     id("systemStatus").classList.add("system-status-alarm");
   } else {
     id("systemStatus").classList.remove("system-status-alarm");
+    if (stateName !== "Alarm") {
+      probe_alarm_suppress = false;
+    }
   }
 
   const clickable = clickableFromStateName(stateName, hasSD);
@@ -857,6 +861,7 @@ const grblHandleMessage = (msg) => {
   if (valueStartsWith(msg, ["error:", "ALARM:", "Hold:", "Door:"])) {
     if (probe_progress_status !== 0) {
       if (valueStartsWith(msg, ["ALARM:"])) {
+        probe_alarm_suppress = true;
         probe_failed_notification("Probe connection failed");
         SendPrinterCommand("$X", true, null, null, 114, 1);
         return;

--- a/ESP3D-WEBUI/www/js/grbl.js
+++ b/ESP3D-WEBUI/www/js/grbl.js
@@ -856,6 +856,11 @@ const grblHandleMessage = (msg) => {
   }
   if (valueStartsWith(msg, ["error:", "ALARM:", "Hold:", "Door:"])) {
     if (probe_progress_status !== 0) {
+      if (valueStartsWith(msg, ["ALARM:"])) {
+        probe_failed_notification("Probe connection failed");
+        SendPrinterCommand("$X", true, null, null, 114, 1);
+        return;
+      }
       probe_failed_notification();
     }
     if (grbl_error_msg.length === 0) {


### PR DESCRIPTION
Fixes #1081

@IDAbbott — this is a fresh, focused take on the `ZNaN` probe bug from #1081. It replaces #1082, which drifted onto the alarm/LED work; the red LED is tracked separately (see below), because it cannot be fixed from the Web UI at all.

## The bug

After a successful probe touch, `grblGetProbeResult` built the retract jog by reading the DOM directly:

```js
`$J=G90 G21 F1000 Z${getValueFloat("probetouchplatethickness") + getValueFloat("grblpanel_proberetract")}`
```

`"probetouchplatethickness"` is the *preference* id. No element has that id, so the lookup returned `NaN`, and the jog went out as `$J=G90 G21 F1000 ZNaN` — exactly the console output in the issue:

```
[PRB:0.401,186.810,30.600,1.616,0.000:1]
$J=G90 G21 F1000 ZNaN
[MSG:INFO: Probe offset applied:]
ok
ERROR:2
```

## The fix

**`ESP3D-WEBUI/www/js/grbl.js` — `grblGetProbeResult`**

Rather than correct the element id, build the retract from the values `StartProbeProcess()` already validated and sent. Reading the fields a second time lets the retract disagree with the `P` word the probe actually ran with: edit the plate thickness while a probe is in flight and the machine probes with the old thickness but retracts to a height computed from the new one — wrong bit height, and no error to make it visible.

The jog is also skipped entirely if the number is not finite, so a malformed `Z` word can no longer reach the firmware by any route.

**`ESP3D-WEBUI/www/js/grbl.js` — `checkProbeValue`**

This was guarded by `if (!("value" in pv))`, so it read each probe field exactly once per page load and never again. Two consequences: edits made in the probe panel were silently ignored, and a single out-of-range entry latched `NaN` permanently, blocking every later probe. It now re-reads the field on each check. This is required for the change above to be correct — otherwise the cached values it now trusts could be stale.

## Verification

Each version was run against a harness that drives `StartProbeProcess()` and `grblGetProbeResult()` over a stub DOM and records the G-code actually emitted:

| scenario | `Maslow-Main` | #1082 | this PR |
| --- | --- | --- | --- |
| probe, thickness 3, retract 1 | `ZNaN` | `Z4` | `Z4` |
| thickness edited to 12.7, probe again | probes `P3`, jogs `ZNaN` | probes **`P3`**, jogs **`Z13.7`** | probes `P12.7`, jogs `Z13.7` |
| thickness set to 1000 (out of range) | silently probes `P3` | silently probes `P3` | rejected with an alert |
| probe reports no contact | probe-failed dialog | probe-failed dialog | probe-failed dialog |

## To test

- [ ] Run a Z probe with a touch plate and confirm the bit retracts to the plate thickness plus the retract distance, with no `ERROR:2` in the console
- [ ] Change the plate thickness in the probe panel and probe again; confirm the new value is used for both the probe and the retract
- [ ] Probe with nothing connected and confirm the probe-failed dialog still appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)