### PR TITLE
Stop every alarm from latching the red LED

### DIFF
--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -16,7 +16,7 @@ The Red LED signals error conditions that require attention. There are two disti
 
 #### Slow Blink (300 ms on / 300 ms off) — Error / Emergency Stop
 
-The Red LED blinks slowly when `Maslow.error` is set to `true`. This state persists until the machine is power-cycled. The machine will not respond to movement commands while in this state.
+The Red LED blinks slowly when `Maslow.error` is set to `true`. The machine will not respond to movement commands while in this state, and it persists until the alarm is cleared with `$X`.
 
 Possible causes:
 
@@ -27,7 +27,9 @@ Possible causes:
 | **Emergency stop command** | The `$ESTOP` command was sent (e.g. via the web interface E-Stop button). |
 | **Position error > 15 mm** | While running a G-code job, an axis drifted more than 15 mm from its target position for more than 5 consecutive checks. This usually indicates a belt that has gone slack, a broken or disconnected belt, or a mechanical obstruction. |
 
-**Recovery:** Power the machine off and back on. Investigate the error message that was printed in the console/log when the LED started blinking—it will name the specific axis and cause.
+**Recovery:** Fix the underlying cause, then clear the alarm with `$X` (the **Clear** button in the web interface). Investigate the error message that was printed in the console/log when the LED started blinking—it will name the specific axis and cause.
+
+`$X` turns the LED off and re-enables motion, so only use it once you have dealt with the cause. After clearing a position error, re-check belt tension and confirm the machine position before cutting.
 
 #### Rapid Double-Blink (100 ms on / 100 ms off / 100 ms on / 800 ms pause) — Watchdog Fired
 
@@ -35,7 +37,7 @@ Both the **Red LED and the WiFi LED** blink together in a rapid double-blink pat
 
 All motors are stopped immediately when this occurs.
 
-**Recovery:** Power the machine off and back on. If this happens repeatedly, check for heavy WiFi traffic, large file uploads, or other operations that may be blocking the motion-control task.
+**Recovery:** Clear the alarm with `$X` (the **Clear** button in the web interface). If this happens repeatedly, check for heavy WiFi traffic, large file uploads, or other operations that may be blocking the motion-control task.
 
 ### WiFi LED
 

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -201,9 +201,9 @@ For a full explanation of each error condition see the [Troubleshooting Guide](.
 
 ### Red LED is blinking
 
-The Red LED blinks slowly (300 ms on/off) when the machine has detected an error. Open the web interface console to read the error message. Common causes are a disconnected encoder or motor cable, a belt that has gone slack, or an emergency stop triggered during a job. Power-cycle the machine after fixing the underlying problem.
+The Red LED blinks slowly (300 ms on/off) when the machine has detected an error. Open the web interface console to read the error message. Common causes are a disconnected encoder or motor cable, a belt that has gone slack, or an emergency stop triggered during a job. After fixing the underlying problem, press **Clear** in the web interface (or send `$X`) to turn the LED off and re-enable motion.
 
-If **both** the Red and WiFi LEDs flash together in a rapid double-blink, the motion-control watchdog fired. Power-cycle the machine.
+If **both** the Red and WiFi LEDs flash together in a rapid double-blink, the motion-control watchdog fired. Press **Clear** (or send `$X`) to clear it. If it keeps happening, power-cycle the machine and check for large uploads or heavy WiFi traffic while the machine is running.
 
 ### Cannot Connect to WiFi
 

--- a/firmware/FluidNC/src/Maslow/Maslow.cpp
+++ b/firmware/FluidNC/src/Maslow/Maslow.cpp
@@ -91,6 +91,7 @@ void Maslow_::begin(void (*sys_rt)()) {
     pinMode(REDLED, OUTPUT);
 
     digitalWrite(ETHERNETLEDPIN, LOW);
+    digitalWrite(REDLED, LOW);
 
     pinMode(SERVOFAULT, INPUT);
 
@@ -1196,6 +1197,42 @@ void Maslow_::panic() {
 // intentional blocking operations (e.g. writing config to LittleFS).
 void Maslow_::resetUpdateWatchdog() {
     lastCallToUpdate = millis();
+}
+
+// Clears a latched error or watchdog condition so the machine can be used again
+// without a power cycle.  Both latches make update() return early forever, so the
+// red LED blinks and all motion is refused until something clears them; $X is the
+// command the user already reaches for to acknowledge an alarm, so it clears them
+// here.  Returns true if a latched condition was actually cleared.
+bool Maslow_::clearError() {
+    // The LED is driven low unconditionally: if nothing is latched it is already off,
+    // and this also picks up the case where a blink left it mid-cycle.
+    digitalWrite(REDLED, LOW);
+
+    if (!error && !watchdogFired) {
+        return false;
+    }
+
+    if (watchdogFired) {
+        log_warn("Clearing update watchdog. Motion is enabled again - if this repeats, find what is blocking the "
+                 "processor before running a job");
+        digitalWrite(WIFILED, LOW);  // the watchdog pattern blinks this one too
+    }
+    if (error) {
+        log_warn("Clearing error state. Motion is enabled again - make sure the cause was fixed, then re-check belt "
+                 "tension and machine position before cutting");
+    }
+
+    error         = false;
+    watchdogFired = false;
+    errorMessage  = "";
+
+    // Both early returns skip the point where lastCallToUpdate is refreshed, so by now it
+    // is far in the past.  Without this the update watchdog re-fires on the very next call
+    // and the LED comes straight back on.
+    resetUpdateWatchdog();
+
+    return true;
 }
 
 //Emergency Stop

--- a/firmware/FluidNC/src/Maslow/Maslow.h
+++ b/firmware/FluidNC/src/Maslow/Maslow.h
@@ -115,6 +115,12 @@ public:
     void   panic();
     void   resetUpdateWatchdog();
 
+    /** Clears a latched error or watchdog condition and turns the red LED off.
+     *  Called when the user clears the alarm with $X.  Returns true if a latched
+     *  condition was actually cleared.  Before this existed both latches were
+     *  permanent and the only recovery was a power cycle. */
+    bool   clearError();
+
     // Set true during file/firmware uploads to suppress the update-loop watchdog.
     // Flash write operations stall both CPU cores; without this flag the 100 ms
     // watchdog fires spuriously and latches the red LED until a power cycle.

--- a/firmware/FluidNC/src/ProcessSettings.cpp
+++ b/firmware/FluidNC/src/ProcessSettings.cpp
@@ -293,6 +293,13 @@ static Error disable_alarm_lock(const char* value, WebUI::AuthenticationLevel au
 
         // Don't run startup script. Prevents stored moves in startup from causing accidents.
     }  // Otherwise, no effect.
+
+    // Clear any latched Maslow error or update-watchdog condition and turn the red LED off.
+    // Those latches outlive the alarm state that raised them, so this runs regardless of the
+    // state above; it is deliberately after the isStuck() check, so a genuinely stuck control
+    // pin still refuses to unlock.
+    Maslow.clearError();
+
     return Error::Ok;
 }
 static Error report_ngc(const char* value, WebUI::AuthenticationLevel auth_level, Channel& out) {

--- a/firmware/FluidNC/src/Protocol.cpp
+++ b/firmware/FluidNC/src/Protocol.cpp
@@ -446,6 +446,12 @@ void protocol_execute_realtime() {
 static void alarm_msg(ExecAlarm alarm_code) {
     log_to(allChannels, "ALARM:", static_cast<int>(alarm_code));
     delay_ms(500);  // Force delay to ensure message clears serial write buffer.
+
+    // That delay blocks this task, and this task is the one that calls Maslow.update().  The
+    // Maslow update watchdog trips after 100 ms, so without this every alarm - however
+    // harmless, including a probe that simply never touched off - latched the watchdog and
+    // left the red LED blinking with the machine unusable until a power cycle.
+    Maslow.resetUpdateWatchdog();
 }
 
 // Executes run-time commands, when required. This function is the primary state
@@ -466,6 +472,9 @@ static void protocol_do_alarm() {
         rtReset = false;  // Disable any existing reset
         do {
             protocol_handle_events();
+            // This loop does not call Maslow.update() either, so keep its watchdog fed for the
+            // same reason as above - the wait here is intentional and must not latch the LED.
+            Maslow.resetUpdateWatchdog();
             // Block everything except reset and status reports until user issues reset or power
             // cycles. Hard limits typically occur while unattended or not paying attention. Gives
             // the user and a GUI time to do what is needed before resetting, like killing the


### PR DESCRIPTION
@IDAbbott — this is the red LED problem you kept reporting in #1082. You were right that it was never fixed, and it turned out not to be a Web UI issue at all, which is why none of the JavaScript changes there made any difference. It is also not specific to probing: **every** alarm did this.

## Root cause

`alarm_msg()` in `FluidNC/src/Protocol.cpp` flushes the serial buffer with a blocking delay:

```cpp
static void alarm_msg(ExecAlarm alarm_code) {
    log_to(allChannels, "ALARM:", static_cast<int>(alarm_code));
    delay_ms(500);  // Force delay to ensure message clears serial write buffer.
}
```

`delay_ms()` is `vTaskDelay()`, and it blocks the same task that calls `Maslow.update()`. The Maslow update watchdog trips after 100 ms (`UPDATE_WATCHDOG_MS`), so the next call to `update()` always measured a ~500 ms gap, set `watchdogFired` and called `panic()`.

From that point `update()` returns early forever:

```cpp
if (watchdogFired) {
    stopMotors();
    ... blink RED + WiFi ...
    return;
}
```

Red and WiFi LEDs double-blinking, every movement command refused, and nothing anywhere in the firmware ever cleared the flag — which is exactly why `$X` appeared to do nothing and only a power cycle helped.

So a Z probe that simply travelled its full distance without touching off — a completely harmless outcome — bricked the machine until it was power cycled. The `do { protocol_handle_events(); } while (!rtReset);` loop just below has the same problem for hard and soft limits.

## Changes

**`FluidNC/src/Protocol.cpp`** — feed the update watchdog across both intentional waits, the way file and firmware uploads already do via `uploadInProgress`. This is the actual fix; the LED no longer comes on for a routine alarm.

**`FluidNC/src/Maslow/Maslow.cpp`, `Maslow.h`** — add `Maslow_::clearError()`. Neither `error` nor `watchdogFired` had any way to be cleared short of a power cycle, so even a genuine fault left the machine dead after the operator had dealt with it. This clears both flags, turns the red LED off, and refreshes `lastCallToUpdate` — that last part matters, because both early returns skip the point where it is normally refreshed, so without it the watchdog re-fires on the very next call and the LED comes straight back on.

**`FluidNC/src/ProcessSettings.cpp`** — call it from `$X`, which is what your **Clear** button already sends. It runs after the existing `isStuck()` check, so a genuinely stuck control pin still refuses to unlock.

**`begin()`** — drive the red LED low at startup. It set the pin to `OUTPUT` but never wrote it, unlike the Ethernet LED next to it.

**Docs** — `docs/Troubleshooting.md` and `docs/user-guide/README.md` both told users to power-cycle; updated to describe clearing with `$X`.

## One thing worth a second opinion, @BarbourSmith

`$X` now clears `Maslow.error`, which re-enables motion after an e-stop. That is what was asked for and it matches normal GRBL `$X` semantics, but it does change documented behaviour: previously a position-error e-stop or a missing encoder at startup required a power cycle. `clearError()` logs prominently what it cleared and what to re-check, and the docs now say to fix the cause first. If you would rather `$X` only cleared the watchdog latch and left a real e-stop needing a power cycle, that is a two-line change — say the word.

Note the root-cause fix alone stops the LED coming on for routine alarms, so this question only affects recovery from genuine faults.

## To test

- [ ] Run a Z probe with nothing connected so it exceeds max travel; confirm the red LED stays off and the machine still jogs afterwards
- [ ] Confirm the "Probe failed" dialog still appears and `$X` returns the machine to Idle
- [ ] Trigger `$ESTOP`, confirm the red LED blinks, then press **Clear** and confirm the LED goes out and the machine moves again
- [ ] Run a normal job afterwards to confirm nothing about normal alarm handling regressed

Probe retract `ZNaN` from #1081 is fixed separately in #1086.

🤖 Generated with [Claude Code](https://claude.com/claude-code)