### PR TITLE
Hide number input arrows in tablet popups

### DIFF
--- a/ESP3D-WEBUI/www/css/tablet.css
+++ b/ESP3D-WEBUI/www/css/tablet.css
@@ -911,4 +911,11 @@ float: left;
 
 .calibration-modal-input {
 width: 100%;
+-moz-appearance: textfield;
+}
+
+.calibration-modal-input::-webkit-inner-spin-button,
+.calibration-modal-input::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
 }


### PR DESCRIPTION
## Summary
- Hide native number-input spin buttons in tablet modal fields.
- Applies to the Configuration, Scale and Thickness, Set Home, Work Area, Park, and Tension Limit popups.

## Validation
- npm run build:en
- git diff --check